### PR TITLE
fix: fix concurrency issues in tx status update

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -361,7 +361,7 @@ def get_transaction_count(
 
 def get_transaction_by_hash(
     transactions_processor: TransactionsProcessor, transaction_hash: str
-) -> dict:
+) -> dict | None:
     return transactions_processor.get_transaction_by_hash(transaction_hash)
 
 

--- a/frontend/src/hooks/useTransactionListener.ts
+++ b/frontend/src/hooks/useTransactionListener.ts
@@ -33,8 +33,6 @@ export function useTransactionListener() {
 
     const newTx = await getTransaction(hash, requestTime);
 
-    if (!newTx) return;
-
     if (!newTx) {
       console.warn('Server tx not found for local tx:', newTx);
       transactionsStore.removeTransaction(newTx);

--- a/frontend/src/hooks/useTransactionListener.ts
+++ b/frontend/src/hooks/useTransactionListener.ts
@@ -5,7 +5,6 @@ import { useWebSocketClient } from '@/hooks';
 export function useTransactionListener() {
   const transactionsStore = useTransactionsStore();
   const webSocketClient = useWebSocketClient();
-  // Track the latest request timestamp for each transaction
   const latestRequestTimes = new Map<string, number>();
 
   function init() {
@@ -16,22 +15,18 @@ export function useTransactionListener() {
   }
 
   async function getTransaction(hash: string, requestTime: number) {
-    // console.log(`🔄 Fetching transaction ${hash}`);
     const result = await transactionsStore.getTransaction(hash);
 
     // Only process the result if this is still the latest request for this hash
     if (latestRequestTimes.get(hash) === requestTime) {
-      // console.log(`✅ Fetched status: ${result.status}`);
       return result;
     } else {
-      // console.log(`⏭️ Skipping outdated result for ${hash}`);
       return null;
     }
   }
 
   async function handleTransactionStatusUpdate(eventData: any) {
-    const { hash, new_status } = eventData.data;
-    console.log(`📥 Received update for hash: ${new_status}`);
+    const { hash } = eventData.data;
 
     const requestTime = Date.now();
     latestRequestTimes.set(hash, requestTime);
@@ -40,9 +35,6 @@ export function useTransactionListener() {
 
     if (!newTx) return;
 
-    // console.log(`📤 Processing update for hash: ${hash}`, newTx);
-
-    // console.log('newTx', newTx.status);
     if (!newTx) {
       console.warn('Server tx not found for local tx:', newTx);
       transactionsStore.removeTransaction(newTx);
@@ -54,8 +46,8 @@ export function useTransactionListener() {
     );
 
     if (!currentTx) {
+      // This happens when local transactions get cleared (e.g. user clears all txs or deploys new contract instance)
       console.warn('Current tx not found:', hash);
-      // This happens regularly when local transactions get cleared (e.g. user clears all txs or deploys new contract instance)
       return;
     }
 

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -63,8 +63,6 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
           return;
         }
 
-        console.log('newTx', newTx);
-
         updateTransaction(newTx);
       }),
     );

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -35,11 +35,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
         data: tx,
       });
 
-      if (
-        currentTx.status === 'ACCEPTED' &&
-        currentTx.type === 'deploy' &&
-        tx.status === 'FINALIZED'
-      ) {
+      if (currentTx.type === 'deploy' && tx.status === 'FINALIZED') {
         contractsStore.addDeployedContract({
           contractId: currentTx.localContractId,
           address: tx.data.contract_address,

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -61,6 +61,14 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     await Promise.all(
       pendingTxs.map(async (tx) => {
         const newTx = await getTransaction(tx.hash);
+
+        if (!newTx) {
+          removeTransaction(tx);
+          return;
+        }
+
+        console.log('newTx', newTx);
+
         updateTransaction(newTx);
       }),
     );

--- a/frontend/test/unit/stores/transactions.test.ts
+++ b/frontend/test/unit/stores/transactions.test.ts
@@ -28,6 +28,9 @@ const testTransaction: TransactionItem = {
   type: 'deploy',
   status: 'PENDING',
   contractAddress: '0xAf4ec2548dBBdc43ab6dCFbD4EdcEedde3FEAFB5',
+  data: {
+    contract_address: '0xAf4ec2548dBBdc43ab6dCFbD4EdcEedde3FEAFB5',
+  },
   localContractId: '47490604-6ee9-4c0e-bf31-05d33197eedd',
 };
 


### PR DESCRIPTION
Fixes #605 

# What

- Added a time tracking system for the fetching of updated tx data to account for rapid websocket events resulting in concurrent requests not always resolving in the right order

# Why

- to fix a bug

# Testing done

- tested the bug fix
- frontend unit OK

# Decisions made

- Initially tried with a deboucing system but didn't manage to make it work, so switched to a timestamp tracking system
- Allowed get transaction endpoint to return null if a tx doesn't exist

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- deploy contracts and fire write transactions; all the statuses should eventually properly end up in **finalized** state

# User facing release notes

- Fixed a bug where the statuses wouldn't update properly in the transaction list
