### PR TITLE
feat: adding ARM64

### DIFF
--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           context: ${{ inputs.docker_build_context }}
           file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Fixes #640 

## What

- Updated the GitHub Actions workflow to enable multi-platform support for Docker images.
- Added `platforms: linux/amd64,linux/arm64` to the `docker/build-and-push-image` step.
- Ensured the workflow builds and pushes images for both `amd64` and `arm64` architectures to the Docker registry.

## Why

- To support both x86-based and ARM-based systems (e.g., Apple Silicon and ARM servers).
- This ensures broader compatibility for users and developers running the simulator on different architectures.

## Testing done

- Verified that images build successfully for both `amd64` and `arm64` platforms using `docker buildx build`.
- Inspected the generated image manifests to confirm both architectures are included.
- Confirmed the workflow runs as expected without breaking existing functionality.

## Decisions made

- Decided to update only the GitHub Actions workflow for now, leaving `docker-compose.yml` unchanged as it is platform-agnostic and does not require modifications.
- Chose not to enforce specific platforms in `docker-compose.yml` to allow Docker to select the appropriate platform based on the host system.

## Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Reviewing tips

- Focus on the changes made to the GitHub Actions workflow, specifically the `platforms` field in the `docker/build-and-push-image` step.
- Verify that the updated workflow supports multi-platform builds without introducing regressions.

## User facing release notes

- The Docker images for the simulator now support both `amd64` and `arm64` platforms, ensuring compatibility with x86 and ARM-based systems.
