### PR TITLE
feat: workflow_dispatch Trigger

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -1,8 +1,8 @@
-name: Create releases from main every day
+name: Create releases from main
 on:
   schedule:
     - cron: "00 08 * * 1-4" # 08:00 AM (UTC) from Monday to Thursday
-
+  workflow_dispatch:
 permissions:
   contents: read # for checkout
 


### PR DESCRIPTION
Fixes #651

# What

- Added `workflow_dispatch` trigger to the "Create releases from main every day" workflow, allowing manual execution of the workflow.
- Retained the existing `cron` schedule for automatic execution.

# Why

- To provide flexibility to trigger the release workflow manually when needed, such as for urgent releases or testing.
- Ensures developers can bypass the scheduled timing without making code changes to the workflow.

# Testing done

- Manually triggered the workflow via the **Actions** tab to verify the new `workflow_dispatch` trigger works correctly.
- Confirmed that the latest changes from the `main` branch were included in the run.
- Validated that all steps (release creation and Docker image push) executed successfully without errors.

# Decisions made

- Kept the existing `cron` schedule untouched to ensure the workflow continues running automatically on specified days and times.
- Did not add input parameters to `workflow_dispatch` to keep the manual trigger simple.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Check the updated `.github/workflows/create-releases.yml` file for the `workflow_dispatch` addition.
- Confirm no other parts of the workflow were unintentionally changed.

# User facing release notes

The release workflow now supports manual execution via the **Actions** tab in addition to its existing daily schedule (Monday to Thursday at 08:00 UTC). This allows for on-demand release creation when necessary.
