### PR TITLE
feat: generating tags with semver

### DIFF
--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -67,6 +67,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=latest
+            type=semver,pattern={{version}}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Fixes #601 

# What

- Updated the `docker-build-and-push-image.yml` workflow to include semantic versioning for Docker tags alongside the `latest` tag.
- Modified the `docker/metadata-action` step to use `type=semver,pattern={{version}}` and `type=raw,value=latest` for consistent tagging.
- Ensured local testing compatibility by setting `push: false` in the `docker/build-push-action` during testing.

# Why

- To ensure Docker images are tagged with both `latest` and semantic versions (e.g., `0.26.0`), improving traceability and version control for image consumers.

# Testing done

- Simulated a Git tag trigger (`v0.26.0`) using `act` to verify correct image tagging (`latest` and `0.26.0`).
- Built and tagged images locally without pushing to Docker Hub.

# Decisions made

- Decided to use `type=semver,pattern={{version}}` to extract semantic version tags from Git tags automatically.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Verify the `Docker Metadata` and `Build and push` steps for correct tag handling and local testing compatibility.
- Check that the workflow works as intended for both `push` events triggered by Git tags and manual `workflow_dispatch` runs.

# User facing release notes

- Docker images are now tagged with both `latest` and semantic versions (e.g., `0.26.0`)
