### PR TITLE
feat: pushing version when workflow is called using schedule

### DIFF
--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -31,25 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # TODO: Once we have the 1Password service account token, we can use the following action to load secrets
-      # "better done than perfect"
-
-      # - name: Load secrets from 1Password
-      #   uses: 1password/load-secrets-action/configure@v1
-      #   id: op-load-secret
-      #   with:
-      #     service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      #   env:
-      #     DOCKERHUB_USERNAME:
-      #     DOCKERHUB_TOKEN:
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ inputs.dockerhub_username }}
           password: ${{ secrets.dockerhub_token }}
-          # username: ${{ steps.op-load-secret.outputs.DOCKERHUB_USERNAME }}
-          # password: ${{ steps.op-load-secret.outputs.DOCKERHUB_TOKEN }}
 
       - name: Create .env file
         run: cp .env.example .env
@@ -57,7 +43,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # jsonrpc
+      - name: Fetch All Tags
+        run: git fetch --tags
+
+      - name: Get the Most Recent Git Tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -65,9 +59,8 @@ jobs:
           images: |
             ${{ inputs.dockerhub_repo }}
           tags: |
-            type=ref,event=tag
-            type=raw,value=latest
-            type=semver,pattern={{version}}
+            ${{ env.latest_tag }}
+            latest
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Fixes #686 

# What

- Implemented logic to dynamically fetch the latest Git tag for use in Docker image tagging.
- Updated the workflow to use the fetched tag 

# Why

- To ensure that Docker images are consistently tagged with the most recent Git tag, improving traceability and alignment with the repository's versioning strategy.
- Adds more flexibility and reliability to the workflow by using Git's tag history.

# Testing done

- Tested the solution by triggering the workflow directly from my `686-not-pushing-version-when-the-release-workflow-is-called-using-schedule` branch using GitHub CLI.
- The successful runs can be observed in the Actions history under this branch.

# Decisions made

- Decided to fetch the most recent Git tag dynamically instead of relying on `package.json` or fixed tags for better traceability.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the `git fetch --tags` and `git describe` steps to ensure they correctly handle fetching and determining the latest tag.
- Verify that the workflow tags the Docker image with both the latest Git tag and `latest`.

# User facing release notes

- Docker images are now automatically tagged with the most recent Git tag and `latest`, ensuring better version traceability and alignment with repository releases.
