### PR TITLE
fix: adding Hardhat Dockerfile in GitHub Workflow

### DIFF
--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -50,3 +50,13 @@ jobs:
       dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
     secrets:
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  hardhat:
+    uses: ./.github/workflows/docker-build-and-push-image.yml
+    with:
+      docker_build_context: .
+      dockerfile: docker/Dockerfile.hardhat
+      dockerhub_repo: yeagerai/simulator-hardhat
+      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes #692 

# What

- Added a `hardhat` step to the GitHub workflow to build and push a Docker image for the Hardhat service.
- Configured the step to use the `docker-build-and-push-image.yml` reusable workflow with appropriate parameters:
  - `docker_build_context`: `.`
  - `dockerfile`: `docker/Dockerfile.hardhat`
  - `dockerhub_repo`: `yeagerai/simulator-hardhat`
  - `dockerhub_username`: `${{ vars.DOCKERHUB_USERNAME }}`
  - `dockerhub_token`: `${{ secrets.DOCKERHUB_TOKEN }}`

# Why

- To address the issue of missing Hardhat Docker images in the registry.
- To ensure the Hardhat service is available for CLI and dependent services, aligning it with other Studio services.

# Testing done

- Verified workflow syntax locally.
- Confirmed similar jobs for other services (e.g., `jsonrpc`, `frontend`) function as expected using the reusable workflow.

# Decisions made

- Used the existing reusable workflow for consistency across services.
- Chose not to add additional Dockerfile-specific testing in this PR, as the reusable workflow already ensures proper image building.

# Checks

- [x] I have tested this code.
- [x] I have reviewed my own PR.
- [x] I have created an issue for this PR.
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

# Reviewing tips

- Focus on the added `hardhat` step in the workflow and confirm the parameters are correct.
- Check the reusable workflow configuration for consistency with other services.

# User facing release notes

- Added a Hardhat Docker image to the CI/CD workflow. The image is now published to Docker Hub, making it available for use in Studio and CLI-related services.
