### PR TITLE
conditionnaly use chain depending on environment

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "defu": "^6.1.4",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^0.4.7",
+    "genlayer-js": "^0.4.8",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "defu": "^6.1.4",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^0.4.6",
+    "genlayer-js": "^0.4.7",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -4,6 +4,7 @@ export const useConfig = () => {
   const canUpdateProviders = !isHostedEnvironment;
 
   return {
+    isHostedEnvironment,
     canUpdateValidators,
     canUpdateProviders,
   };

--- a/frontend/src/hooks/useGenlayer.ts
+++ b/frontend/src/hooks/useGenlayer.ts
@@ -1,13 +1,15 @@
-import { simulator } from 'genlayer-js/chains';
+import { simulator, localNetwork } from 'genlayer-js/chains';
 import { createClient, createAccount } from 'genlayer-js';
 import type { GenLayerClient } from 'genlayer-js/types';
 import { watch } from 'vue';
+import { useConfig } from '@/hooks/useConfig';
 import { useAccountsStore } from '@/stores';
 
 let client: GenLayerClient<typeof simulator> | null = null;
 
 export function useGenlayer() {
   const accountsStore = useAccountsStore();
+  const { isHostedEnvironment } = useConfig();
 
   if (!client) {
     initClient();
@@ -22,7 +24,7 @@ export function useGenlayer() {
 
   function initClient() {
     client = createClient({
-      chain: simulator,
+      chain: isHostedEnvironment ? simulator : localNetwork,
       account: createAccount(accountsStore.currentPrivateKey || undefined),
     });
   }


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #699

# What

- Conditionnaly initialize the genlayer client with the right chain depending on local network VS hosted studio.

# Why

- To handle both environments and have RPC calls working.

# Testing done

- not yet

# Decisions made

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
