### PR TITLE
fix: adapt endpoint for genlayer js rpc

### DIFF
--- a/frontend/src/hooks/useGenlayer.ts
+++ b/frontend/src/hooks/useGenlayer.ts
@@ -23,6 +23,7 @@ export function useGenlayer() {
   function initClient() {
     client = createClient({
       chain: simulator,
+      endpoint: import.meta.env.VITE_JSON_RPC_SERVER_URL,
       account: createAccount(accountsStore.currentPrivateKey || undefined),
     });
   }


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #699 

# What

- pass the endpoint for genlayer RPC

# Why

- to have calls going through genlayer-js working on both environments


# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# User facing release notes

- Fixed genlayer-js RPC calls in hosted studio
