### PR TITLE
fix: catch exception to keep loop running

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -573,33 +573,38 @@ class ConsensusAlgorithm:
         FINALITY_WINDOW = int(os.getenv("FINALITY_WINDOW"))
         print(" ~ ~ ~ ~ ~ FINALITY WINDOW: ", FINALITY_WINDOW)
         while True:
-            with self.get_session() as session:
-                chain_snapshot = ChainSnapshot(session)
-                transactions_processor = TransactionsProcessor(session)
-                accepted_transactions = chain_snapshot.get_accepted_transactions()
-                for transaction in accepted_transactions:
-                    transaction = transaction_from_dict(transaction)
-                    if not transaction.appealed:
-                        if (
-                            int(time.time()) - transaction.timestamp_accepted
-                        ) > FINALITY_WINDOW:
-                            self.finalize_transaction(
+            try:
+                with self.get_session() as session:
+                    chain_snapshot = ChainSnapshot(session)
+                    transactions_processor = TransactionsProcessor(session)
+                    accepted_transactions = chain_snapshot.get_accepted_transactions()
+                    for transaction in accepted_transactions:
+                        transaction = transaction_from_dict(transaction)
+                        if not transaction.appealed:
+                            if (
+                                int(time.time()) - transaction.timestamp_accepted
+                            ) > FINALITY_WINDOW:
+                                self.finalize_transaction(
+                                    transaction,
+                                    transactions_processor,
+                                )
+                                session.commit()
+                        else:
+                            transactions_processor.set_transaction_appeal(
+                                transaction.hash, False
+                            )
+                            self.commit_reveal_accept_transaction(
                                 transaction,
                                 transactions_processor,
+                                lambda contract_address: contract_snapshot_factory(
+                                    contract_address, session, transaction
+                                ),
                             )
                             session.commit()
-                    else:
-                        transactions_processor.set_transaction_appeal(
-                            transaction.hash, False
-                        )
-                        self.commit_reveal_accept_transaction(
-                            transaction,
-                            transactions_processor,
-                            lambda contract_address: contract_snapshot_factory(
-                                contract_address, session, transaction
-                            ),
-                        )
-                        session.commit()
+
+            except Exception as e:
+                print("Error running consensus", e)
+                print(traceback.format_exc())
 
             await asyncio.sleep(1)
 


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #703

# What

<!-- Describe the changes you made. -->

- Added try except in _appeal_window so it won't stop running. 
- Print out the exception for further debug.
- For the hardhat error. The appeal_window will execute normally when a connection is established.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the bug fix by rerunning the studio when there is a transaction that is still in the accepted state in the database.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)