### PR TITLE
fix: consensus deploy contract when finalized

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -411,7 +411,6 @@ class ConsensusAlgorithm:
         self,
         transaction: Transaction,
         transactions_processor: TransactionsProcessor,
-        contract_snapshot_factory: Callable[[str], ContractSnapshot],
     ):
         # temporary, reuse existing code
         # and add other possible states the transaction can go to
@@ -441,13 +440,15 @@ class ConsensusAlgorithm:
             self.msg_handler,
         )
         transactions_processor.create_rollup_transaction(transaction.hash)
-        self.update_contract_state(transaction, contract_snapshot_factory)
 
     def finalize_transaction(
         self,
         transaction: Transaction,
         transactions_processor: TransactionsProcessor,
+        contract_snapshot_factory: Callable[[str], ContractSnapshot],
     ):
+        self.update_contract_state(transaction, contract_snapshot_factory)
+
         consensus_data = transaction.consensus_data
         leader_receipt = consensus_data["leader_receipt"]
         # Finalize transaction
@@ -573,33 +574,38 @@ class ConsensusAlgorithm:
         FINALITY_WINDOW = int(os.getenv("FINALITY_WINDOW"))
         print(" ~ ~ ~ ~ ~ FINALITY WINDOW: ", FINALITY_WINDOW)
         while True:
-            with self.get_session() as session:
-                chain_snapshot = ChainSnapshot(session)
-                transactions_processor = TransactionsProcessor(session)
-                accepted_transactions = chain_snapshot.get_accepted_transactions()
-                for transaction in accepted_transactions:
-                    transaction = transaction_from_dict(transaction)
-                    if not transaction.appealed:
-                        if (
-                            int(time.time()) - transaction.timestamp_accepted
-                        ) > FINALITY_WINDOW:
-                            self.finalize_transaction(
+            try:
+                with self.get_session() as session:
+                    chain_snapshot = ChainSnapshot(session)
+                    transactions_processor = TransactionsProcessor(session)
+                    accepted_transactions = chain_snapshot.get_accepted_transactions()
+                    for transaction in accepted_transactions:
+                        transaction = transaction_from_dict(transaction)
+                        if not transaction.appealed:
+                            if (
+                                int(time.time()) - transaction.timestamp_accepted
+                            ) > FINALITY_WINDOW:
+                                self.finalize_transaction(
+                                    transaction,
+                                    transactions_processor,
+                                    lambda contract_address: contract_snapshot_factory(
+                                        contract_address, session, transaction
+                                    ),
+                                )
+                                session.commit()
+                        else:
+                            transactions_processor.set_transaction_appeal(
+                                transaction.hash, False
+                            )
+                            self.commit_reveal_accept_transaction(
                                 transaction,
                                 transactions_processor,
                             )
                             session.commit()
-                    else:
-                        transactions_processor.set_transaction_appeal(
-                            transaction.hash, False
-                        )
-                        self.commit_reveal_accept_transaction(
-                            transaction,
-                            transactions_processor,
-                            lambda contract_address: contract_snapshot_factory(
-                                contract_address, session, transaction
-                            ),
-                        )
-                        session.commit()
+
+            except Exception as e:
+                print("Error running consensus", e)
+                print(traceback.format_exc())
 
             await asyncio.sleep(1)
 

--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -363,7 +363,6 @@ class ConsensusAlgorithm:
                 transaction_hash=transaction.hash,
             )
         )
-        self.update_contract_state(transaction, contract_snapshot_factory)
 
     def update_contract_state(
         self,

--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -574,38 +574,33 @@ class ConsensusAlgorithm:
         FINALITY_WINDOW = int(os.getenv("FINALITY_WINDOW"))
         print(" ~ ~ ~ ~ ~ FINALITY WINDOW: ", FINALITY_WINDOW)
         while True:
-            try:
-                with self.get_session() as session:
-                    chain_snapshot = ChainSnapshot(session)
-                    transactions_processor = TransactionsProcessor(session)
-                    accepted_transactions = chain_snapshot.get_accepted_transactions()
-                    for transaction in accepted_transactions:
-                        transaction = transaction_from_dict(transaction)
-                        if not transaction.appealed:
-                            if (
-                                int(time.time()) - transaction.timestamp_accepted
-                            ) > FINALITY_WINDOW:
-                                self.finalize_transaction(
-                                    transaction,
-                                    transactions_processor,
-                                    lambda contract_address: contract_snapshot_factory(
-                                        contract_address, session, transaction
-                                    ),
-                                )
-                                session.commit()
-                        else:
-                            transactions_processor.set_transaction_appeal(
-                                transaction.hash, False
-                            )
-                            self.commit_reveal_accept_transaction(
+            with self.get_session() as session:
+                chain_snapshot = ChainSnapshot(session)
+                transactions_processor = TransactionsProcessor(session)
+                accepted_transactions = chain_snapshot.get_accepted_transactions()
+                for transaction in accepted_transactions:
+                    transaction = transaction_from_dict(transaction)
+                    if not transaction.appealed:
+                        if (
+                            int(time.time()) - transaction.timestamp_accepted
+                        ) > FINALITY_WINDOW:
+                            self.finalize_transaction(
                                 transaction,
                                 transactions_processor,
+                                lambda contract_address: contract_snapshot_factory(
+                                    contract_address, session, transaction
+                                ),
                             )
                             session.commit()
-
-            except Exception as e:
-                print("Error running consensus", e)
-                print(traceback.format_exc())
+                    else:
+                        transactions_processor.set_transaction_appeal(
+                            transaction.hash, False
+                        )
+                        self.commit_reveal_accept_transaction(
+                            transaction,
+                            transactions_processor,
+                        )
+                        session.commit()
 
             await asyncio.sleep(1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.backend
-      target: ${BACKEND_BUILD_TARGET:-prod}
+      target: debug
     environment:
       - FLASK_SERVER_PORT=${RPCPORT}
       # TODO: remove this in production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.backend
-      target: debug
+      target: ${BACKEND_BUILD_TARGET:-prod}
     environment:
       - FLASK_SERVER_PORT=${RPCPORT}
       # TODO: remove this in production

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -38,7 +38,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
         data: tx,
       });
 
-      if (currentTx.type === 'deploy' && tx.status === 'ACCEPTED') {
+      if (currentTx.type === 'deploy' && tx.status === 'FINALIZED') {
         contractsStore.addDeployedContract({
           contractId: currentTx.localContractId,
           address: tx.data.contract_address,

--- a/tests/unit/consensus/test_helpers.py
+++ b/tests/unit/consensus/test_helpers.py
@@ -182,13 +182,13 @@ async def _appeal_window(
                     consensus.finalize_transaction(
                         transaction,
                         transactions_processor,
+                        contract_snapshot_factory=contract_snapshot_factory,
                     )
             else:
                 transactions_processor.set_transaction_appeal(transaction.hash, False)
                 consensus.commit_reveal_accept_transaction(
                     transaction,
                     transactions_processor,
-                    contract_snapshot_factory=contract_snapshot_factory,
                 )
 
         await asyncio.sleep(1)


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #708

# What

<!-- Describe the changes you made. -->

- Redo the change so that the contract is deployed when the transaction is finalized. I could not find any other issue than the issue where the appeal window loop does not recover, that blocks the transaction to go to the finalized state.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the bug fix in the localhost and ran the consensus unit tests locally

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Run studio and see code changes

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
Contract is deployed when the transaction is in the finalized state after waiting for the finality window. The write methods will be accessible when the transaction is in the finalized state.