### PR TITLE
feat: removed loader from state prior to final, changed bg color to green when final

### DIFF
--- a/frontend/src/components/Simulator/TransactionItem.vue
+++ b/frontend/src/components/Simulator/TransactionItem.vue
@@ -143,7 +143,14 @@ function prettifyTxData(x: any): any {
     </div>
 
     <div class="flex items-center justify-between gap-2 p-1">
-      <Loader :size="15" v-if="transaction.status !== 'FINALIZED'" />
+      <Loader
+        :size="15"
+        v-if="
+          transaction.status !== 'FINALIZED' &&
+          transaction.status !== 'ACCEPTED' &&
+          transaction.status !== 'UNDETERMINED'
+        "
+      />
 
       <!-- <TransactionStatusBadge
         as="button"
@@ -158,7 +165,12 @@ function prettifyTxData(x: any): any {
         </div>
       </TransactionStatusBadge> -->
 
-      <TransactionStatusBadge class="px-[4px] py-[1px] text-[9px]">
+      <TransactionStatusBadge
+        :class="[
+          'px-[4px] py-[1px] text-[9px]',
+          transaction.status === 'FINALIZED' ? '!bg-green-500' : '',
+        ]"
+      >
         {{ transaction.status }}
       </TransactionStatusBadge>
     </div>
@@ -198,8 +210,20 @@ function prettifyTxData(x: any): any {
             class="text-md mb-1 flex flex-row items-center gap-2 font-semibold"
           >
             Status:
-            <Loader :size="15" v-if="transaction.status !== 'FINALIZED'" />
-            <TransactionStatusBadge>
+            <Loader
+              :size="15"
+              v-if="
+                transaction.status !== 'FINALIZED' &&
+                transaction.status !== 'ACCEPTED' &&
+                transaction.status !== 'UNDETERMINED'
+              "
+            />
+            <TransactionStatusBadge
+              :class="[
+                'px-[4px] py-[1px] text-[9px]',
+                transaction.status === 'FINALIZED' ? '!bg-green-500' : '',
+              ]"
+            >
               {{ transaction.status }}
             </TransactionStatusBadge>
           </p>


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #723 

# What

<!-- Describe the changes you made. -->

- The spinner/loader stops after ACCEPTED and UNDETERMINED.
- When the appeal window finishes, the background is updated to green to show that the transaction is definitive.
- Both apply to the status of the transaction in Transaction section and also in the modal.
![Screenshot 2024-12-10 at 21 27 27](https://github.com/user-attachments/assets/84555752-fd1d-42a4-9c44-751909513449)

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To add more value to the user

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the new feature in the webpage

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Run the studio and see code changes.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
- The spinner/loader next to the transaction state stops after ACCEPTED and UNDETERMINED.
- When the appeal window finishes, the status background is updated to green to show that the transaction is definitive.