### PR TITLE
fix: consensus pending queue runs sequentially

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -178,7 +178,9 @@ class ConsensusAlgorithm:
                         transaction: Transaction = await queue.get()
                         with self.get_session() as session:
 
-                            async def exec_transaction_with_session_handling():
+                            async def exec_transaction_with_session_handling(
+                                session: Session, transaction: Transaction
+                            ):
                                 await self.exec_transaction(
                                     transaction,
                                     TransactionsProcessor(session),
@@ -190,7 +192,11 @@ class ConsensusAlgorithm:
                                 )
                                 session.commit()
 
-                            tg.create_task(exec_transaction_with_session_handling())
+                            tg.create_task(
+                                exec_transaction_with_session_handling(
+                                    session, transaction
+                                )
+                            )
 
             except Exception as e:
                 print("Error running consensus", e)


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #766 

# What

<!-- Describe the changes you made. -->

- Added arguments to exec_transaction_with_session_handling() because tasks are created containing variables outside of the task function. The value of the variable transaction changes because of the for loop. So the created tasks point to the same transaction which won't let the system run the tasks in parallel. Passing the transaction instead of using the local variable solves this behaviour, see screenshots.
![Screenshot 2024-12-19 at 11 39 46](https://github.com/user-attachments/assets/3224c89c-bbf1-49e3-b35a-50774f8d2d3f)
![Screenshot 2024-12-19 at 11 40 10](https://github.com/user-attachments/assets/cc5b1fb1-3af9-4ba6-b2c1-6d58f758773d)
![Screenshot 2024-12-19 at 11 40 53](https://github.com/user-attachments/assets/3c1e2a6e-ea37-4217-939f-cf0cf720b678)

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug and make it more user friendly

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the bug fix in the localhost

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->
I was thinking of making other threads for each contract pending queue but passing the variable solved it.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Run the code, check the code changes

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
For every contract, the transactions get processed sequentially. But between contracts, the transactions are processed in parallel.