### PR TITLE
fix(hardhat): preinstall solidity compiler to speed up container startup

### DIFF
--- a/docker/Dockerfile.hardhat
+++ b/docker/Dockerfile.hardhat
@@ -10,6 +10,9 @@ RUN npm install --ignore-scripts
 
 COPY ./hardhat .
 
+# Download compiler
+RUN npx hardhat compile || true
+
 # Create directories and set permissions
 RUN mkdir -p /app/deployments/localhost && \
     mkdir -p /app/deployments/hardhat && \


### PR DESCRIPTION
Fixes #792 

# What

- Added a step in the `Dockerfile.hardhat` to pre-download the Solidity compiler during the build process.

# Why

- To improve container startup performance by reducing the time spent downloading and compiling Solidity contracts at runtime.
- Enhances developer experience by ensuring the environment is preconfigured.

# Testing done

- Built the Docker image and verified that the Solidity compiler is pre-downloaded during the build step.
- Verified that the container starts without downloading the compiler again
- Successfully deployed contracts using the updated Docker image

# Decisions made

- Decided to preinstall the compiler is to simplify the process and improve image portability.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the `RUN npx hardhat compile || true` addition in the `Dockerfile.hardhat`.
- Verify the change aligns with the goal of improving container startup performance.

# User facing release notes

- **Improved Docker Image for Hardhat**: The Docker image now pre-downloads the Solidity compiler, significantly reducing container startup time and enhancing deployment efficiency.