### PR TITLE
fix: only forbid endpoint, not function

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -148,7 +148,6 @@ def delete_provider(llm_provider_registry: LLMProviderRegistry, id: int) -> None
     llm_provider_registry.delete(id)
 
 
-@check_forbidden_method_in_hosted_studio
 def create_validator(
     validators_registry: ValidatorsRegistry,
     accounts_manager: AccountsManager,
@@ -743,7 +742,11 @@ def register_all_rpc_endpoints(
         method_name="sim_deleteProvider",
     )
     register_rpc_endpoint(
-        partial(create_validator, validators_registry, accounts_manager),
+        partial(
+            check_forbidden_method_in_hosted_studio(create_validator),
+            validators_registry,
+            accounts_manager,
+        ),
         method_name="sim_createValidator",
     )
     register_rpc_endpoint(


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #838

# What
Only fixes the issue's problem

# Why

I am using VALIDATORS_CONFIG_JSON and I need it

# Testing done

Tested changing VALIDATORS_CONFIG_JSON and it works

# Decisions made

We should probably do this with all of the functions

I think there's a problem with the current model: we have mixed our domain logic and our endpoints logic
I think it'd be nice if we were able to extract the logic into it's own module, and then import it from the flask server and expose what we want
Obviously this is a larger issue what I'm fixing here

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

# User facing release notes

Fix bug with `VALIDATORS_CONFIG_JSON`
