### PR TITLE
fix: db-integration-test contains mock error

### DIFF
--- a/tests/db-sqlalchemy/transactions_processor_test.py
+++ b/tests/db-sqlalchemy/transactions_processor_test.py
@@ -63,7 +63,6 @@ def test_transactions_processor(transactions_processor: TransactionsProcessor):
         transaction_type,
         nonce + 1,
         True,
-        None,
         first_transaction_hash,
     )
 

--- a/tests/db-sqlalchemy/transactions_processor_test.py
+++ b/tests/db-sqlalchemy/transactions_processor_test.py
@@ -4,6 +4,8 @@ from unittest.mock import patch, MagicMock
 import os
 import math
 from datetime import datetime
+from web3 import Web3
+from web3.providers import BaseProvider
 
 from backend.database_handler.chain_snapshot import ChainSnapshot
 from backend.database_handler.models import Transactions
@@ -20,12 +22,15 @@ def mock_env_and_web3():
             "HARDHAT_URL": "http://localhost",
             "HARDHAT_PRIVATE_KEY": "0x0123456789",
         },
-    ), patch("web3.Web3.HTTPProvider"), patch(
-        "web3.Web3.eth.accounts",
-        new_callable=MagicMock,
-        return_value=["0x0000000000000000000000000000000000000000"],
-    ):
-        yield
+    ), patch("web3.Web3.HTTPProvider"):
+        web3_instance = Web3(MagicMock(spec=BaseProvider))
+        web3_instance.eth = MagicMock()
+        web3_instance.eth.accounts = ["0x0000000000000000000000000000000000000000"]
+        with patch(
+            "backend.database_handler.transactions_processor.Web3",
+            return_value=web3_instance,
+        ):
+            yield
 
 
 def test_transactions_processor(transactions_processor: TransactionsProcessor):


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #842

# What

<!-- Describe the changes you made. -->

- Changed the patch and mock for eth.accounts

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug in the test

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the bug fix by running the failed test

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->
Fixed the code so the test won't fail. I guess insert_transaction() will change in the future so this patch might be removed or not.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Run test locally: POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/genlayer_state PYTHONPATH=$PWD pytest tests/db-sqlalchemy/transactions_processor_test.py

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
db-integration-test works again