### PR TITLE
fix: return dummy information for metamask compatibility

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -337,12 +337,13 @@ class TransactionsProcessor:
             .all()
         )
 
-        if not transactions:
-            return None
-
-        block_hash = transactions[0].hash
+        block_hash = "0x" + "0" * 64
         parent_hash = "0x" + "0" * 64  # Placeholder for parent block hash
-        timestamp = transactions[0].timestamp_accepted or int(time.time())
+        timestamp = (
+            transactions[0].timestamp_accepted
+            if len(transactions) > 0
+            else int(time.time())
+        )
 
         if include_full_tx:
             transaction_data = [self._parse_transaction_data(tx) for tx in transactions]


### PR DESCRIPTION
Fixes #863 

# What

- Modified block hash and timestamp handling in `transactions_processor.py` to handle empty transaction lists
- Changed default block hash to be zeros instead of accessing first transaction
- Updated timestamp logic to handle cases with no transactions

# Why

- To fix a bug where the processor would return None when no transactions exist
- To provide consistent behavior with default values when processing empty transaction lists
- To prevent potential IndexError when accessing transaction timestamps with empty lists

# Testing done

- Tested transaction processing with empty transaction lists
- Verified default values are correctly set when no transactions exist
- Confirmed existing functionality still works with non-empty transaction lists

# Decisions made

- Used "0x" + "0" * 64 as the default block hash to maintain consistent format
- Kept parent_hash as zeros to maintain existing behavior
- Used current timestamp as fallback when no transactions exist

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# Reviewing tips

Pay special attention to the null handling logic and verify the default values are appropriate for your use case.

# User facing release notes

Fixed an issue where the system would fail when processing empty transaction lists. The system now handles this case gracefully by providing appropriate default values.