### PR TITLE
chore: bumped genlayer-js version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "defu": "^6.1.4",
         "dexie": "^4.0.4",
         "floating-vue": "^5.2.2",
-        "genlayer-js": "^0.6.3",
+        "genlayer-js": "^0.6.4",
         "hash-sum": "^2.0.0",
         "jump.js": "^1.0.2",
         "lodash-es": "^4.17.21",
@@ -3367,6 +3367,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5410,11 +5418,17 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
+      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -5569,9 +5583,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.6.3.tgz",
-      "integrity": "sha512-kVC2pwNRBifkKJ1raBz3vktql9HBJ6OX2yFcBh5BawhO3sHF8X44sUWCqUFB/CjikRRvVnuCdyzL2aE70Ecikw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.6.4.tgz",
+      "integrity": "sha512-tbsBRyVUGZ0a+661ML6wu3U3p5CtHkik7a4qTc68OZgf1pX1G4JBs7CzAmqAkMt8HUyD/J413raDs9Q5s3psWw==",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",
         "typescript-parsec": "^0.3.4",
@@ -6064,10 +6078,11 @@
       }
     },
     "node_modules/is-async-function": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dependencies": {
+        "async-function": "^1.0.0",
         "call-bound": "^1.0.3",
         "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
@@ -6447,11 +6462,11 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dependencies": {
-        "call-bound": "^1.0.2"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "defu": "^6.1.4",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^0.6.3",
+    "genlayer-js": "^0.6.4",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
Fixes #863 

# What

- Updated genlayer-js dependency from v0.6.3 to v0.6.4
- Package-lock.json updated with related dependency changes

# Why

- To incorporate latest genlayer-js bug fixes and improvements

# Testing done

- Verified application functionality with updated dependency
- Confirmed no breaking changes

# Decisions made

- Simple dependency update following semantic versioning

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# User facing release notes

Updated genlayer-js to latest version (0.6.4) with minor improvements and bug fixes.