### PR TITLE
chore: increaded nginx config limits for body size

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -116,6 +116,12 @@ http {
 
             # Ensure proper content type for JSON-RPC
             proxy_set_header Content-Type "application/json";
+
+            # For handling large file uploads
+            client_max_body_size 100M;
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
         }
     }
 }


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #N/A

# What

- Added NGINX configuration for handling large file uploads
- Increased timeouts for proxy operations to 300s
- Set client_max_body_size to 100M

# Why

- To support larger file uploads in the application
- To prevent timeout issues during long-running operations

# Testing done

- Verified large file uploads work correctly
- Tested proxy timeout settings with longer operations

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# User facing release notes

Improved file upload capabilities by increasing maximum file size to 100MB and extending operation timeouts.