### PR TITLE
fix: deploy event and tutorial error

### DIFF
--- a/frontend/src/components/Simulator/ContractInfo.vue
+++ b/frontend/src/components/Simulator/ContractInfo.vue
@@ -2,7 +2,7 @@
 import PageSection from '@/components/Simulator/PageSection.vue';
 import { CheckCircleIcon } from '@heroicons/vue/24/outline';
 import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vue';
-import { useNodeStore } from '@/stores';
+import { useNodeStore, useUIStore } from '@/stores';
 import { useContractQueries, useShortAddress } from '@/hooks';
 import { UploadIcon } from 'lucide-vue-next';
 
@@ -15,6 +15,7 @@ defineProps<{
 
 const emit = defineEmits(['openDeployment']);
 const { isDeployed, address, contract } = useContractQueries();
+const uiStore = useUIStore();
 </script>
 
 <template>
@@ -47,7 +48,9 @@ const { isDeployed, address, contract } = useContractQueries();
     <Alert
       warning
       v-if="
-        !nodeStore.isLoadingValidatorData && !nodeStore.hasAtLeastOneValidator
+        !uiStore.showTutorial &&
+        !nodeStore.isLoadingValidatorData &&
+        !nodeStore.hasAtLeastOneValidator
       "
     >
       You need at least one validator before you can deploy or interact with a

--- a/frontend/src/components/Simulator/TransactionsList.vue
+++ b/frontend/src/components/Simulator/TransactionsList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, defineProps } from 'vue';
+import { ref, computed } from 'vue';
 import { useContractsStore, useTransactionsStore } from '@/stores';
 import { TrashIcon } from '@heroicons/vue/24/solid';
 import TransactionItem from './TransactionItem.vue';

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './useGenlayer';
 export * from './useShortAddress';
 export * from './useConfig';
 export * from './useTransactionListener';
+export * from './useContractListener';

--- a/frontend/src/hooks/useContractListener.ts
+++ b/frontend/src/hooks/useContractListener.ts
@@ -17,11 +17,14 @@ export function useContractListener() {
       (t) => t.hash === eventData.transaction_hash,
     );
 
+    // Check for a local transaction to:
+    // - match the contract file ID since it is only stored client-side
+    // - make sure to scope the websocket event to the correct client
     if (localDeployTx) {
       contractsStore.addDeployedContract({
         contractId: localDeployTx.localContractId,
         address: eventData.data.id,
-        defaultState: eventData.data.data.state, // TODO: ?
+        defaultState: eventData.data.data.state,
       });
     }
   }

--- a/frontend/src/hooks/useContractListener.ts
+++ b/frontend/src/hooks/useContractListener.ts
@@ -11,8 +11,6 @@ export function useContractListener() {
   }
 
   async function handleContractDeployed(eventData: any) {
-    console.log('deployed_contract', eventData);
-
     const localDeployTx = transactionsStore.transactions.find(
       (t) => t.hash === eventData.transaction_hash,
     );

--- a/frontend/src/hooks/useContractListener.ts
+++ b/frontend/src/hooks/useContractListener.ts
@@ -1,0 +1,32 @@
+import { useContractsStore, useTransactionsStore } from '@/stores';
+import { useWebSocketClient } from '@/hooks';
+
+export function useContractListener() {
+  const contractsStore = useContractsStore();
+  const transactionsStore = useTransactionsStore();
+  const webSocketClient = useWebSocketClient();
+
+  function init() {
+    webSocketClient.on('deployed_contract', handleContractDeployed);
+  }
+
+  async function handleContractDeployed(eventData: any) {
+    console.log('deployed_contract', eventData);
+
+    const localDeployTx = transactionsStore.transactions.find(
+      (t) => t.hash === eventData.transaction_hash,
+    );
+
+    if (localDeployTx) {
+      contractsStore.addDeployedContract({
+        contractId: localDeployTx.localContractId,
+        address: eventData.data.id,
+        defaultState: eventData.data.data.state, // TODO: ?
+      });
+    }
+  }
+
+  return {
+    init,
+  };
+}

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -133,7 +133,9 @@ export function useContractQueries() {
         contract_name: contract.value?.name || '',
       });
 
-      transactionsStore.clearTransactionsForContract(contract.value?.id ?? '');
+      await transactionsStore.clearTransactionsForContract(
+        contract.value?.id ?? '',
+      ); // await this to avoid race condition causing the added transaction below to be erased
       transactionsStore.addTransaction(tx);
       contractsStore.removeDeployedContract(contract.value?.id ?? '');
       return tx;

--- a/frontend/src/hooks/useMockContractData.ts
+++ b/frontend/src/hooks/useMockContractData.ts
@@ -11,37 +11,27 @@ export function useMockContractData() {
   };
 
   const mockContractSchema = {
-    class: 'Storage',
-    abi: [
-      {
-        inputs: [
-          {
-            name: 'initial_storage',
-            type: 'string',
-          },
-        ],
-        type: 'constructor',
+    ctor: {
+      kwparams: {},
+      params: [['initial_storage', 'string']],
+    },
+    methods: {
+      get_storage: {
+        kwparams: {},
+        params: [],
+        readonly: true,
+        ret: 'string',
       },
-      {
-        inputs: [],
-        name: 'get_storage',
-        outputs: 'string',
-        type: 'function',
+      update_storage: {
+        kwparams: {},
+        params: [['new_storage', 'string']],
+        readonly: false,
+        ret: 'null',
       },
-      {
-        inputs: [
-          {
-            name: 'update',
-            type: 'string',
-          },
-        ],
-        name: 'new_storage',
-        outputs: '',
-        type: 'function',
-      },
-    ],
+    },
   };
 
+  // FIXME:
   const mockDeploymentTx: TransactionItem = {
     contractAddress: mockContractAddress,
     localContractId: mockContractId,

--- a/frontend/src/hooks/useMockContractData.ts
+++ b/frontend/src/hooks/useMockContractData.ts
@@ -31,7 +31,6 @@ export function useMockContractData() {
     },
   };
 
-  // FIXME:
   const mockDeploymentTx: TransactionItem = {
     contractAddress: mockContractAddress,
     localContractId: mockContractId,

--- a/frontend/src/hooks/useSetupStores.ts
+++ b/frontend/src/hooks/useSetupStores.ts
@@ -5,7 +5,12 @@ import {
   useNodeStore,
   useTutorialStore,
 } from '@/stores';
-import { useDb, useGenlayer, useTransactionListener } from '@/hooks';
+import {
+  useDb,
+  useGenlayer,
+  useTransactionListener,
+  useContractListener,
+} from '@/hooks';
 import { v4 as uuidv4 } from 'uuid';
 
 export const useSetupStores = () => {
@@ -18,6 +23,7 @@ export const useSetupStores = () => {
     const db = useDb();
     const genlayer = useGenlayer();
     const transactionListener = useTransactionListener();
+    const contractListener = useContractListener();
     const contractFiles = await db.contractFiles.toArray();
     const exampleFiles = contractFiles.filter((c) => c.example);
 
@@ -52,6 +58,7 @@ export const useSetupStores = () => {
     transactionsStore.initSubscriptions();
     transactionsStore.refreshPendingTransactions();
     transactionListener.init();
+    contractListener.init();
     contractsStore.getInitialOpenedFiles();
     tutorialStore.resetTutorialState();
     nodeStore.getValidatorsData();

--- a/frontend/src/stores/node.ts
+++ b/frontend/src/stores/node.ts
@@ -123,6 +123,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
 
   const deleteValidator = async (validator: ValidatorModel) => {
     if (validators.value.length === 1) {
+      throw new Error('You must have at least one validator');
     }
     await rpcClient.deleteValidator({
       address: validator.address || '',

--- a/frontend/src/stores/node.ts
+++ b/frontend/src/stores/node.ts
@@ -123,7 +123,6 @@ export const useNodeStore = defineStore('nodeStore', () => {
 
   const deleteValidator = async (validator: ValidatorModel) => {
     if (validators.value.length === 1) {
-      throw new Error('You must have at least one validator');
     }
     await rpcClient.deleteValidator({
       address: validator.address || '',

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -38,14 +38,6 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
         status: tx.status,
         data: tx,
       });
-
-      if (currentTx.type === 'deploy' && tx.status === 'ACCEPTED') {
-        contractsStore.addDeployedContract({
-          contractId: currentTx.localContractId,
-          address: tx.data.contract_address,
-          defaultState: '{}',
-        });
-      }
     } else {
       // Temporary logging to debug always-PENDING transactions
       console.warn('Transaction not found', tx);

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -6,11 +6,13 @@ import TransactionsList from '@/components/Simulator/TransactionsList.vue';
 import { useContractQueries, useConfig } from '@/hooks';
 import MainTitle from '@/components/Simulator/MainTitle.vue';
 import { ref, watch, computed } from 'vue';
-import { useContractsStore, useNodeStore } from '@/stores';
+import { useContractsStore, useNodeStore, useUIStore } from '@/stores';
 import ContractInfo from '@/components/Simulator/ContractInfo.vue';
 import BooleanField from '@/components/global/fields/BooleanField.vue';
 import FieldError from '@/components/global/fields/FieldError.vue';
 import NumberInput from '@/components/global/inputs/NumberInput.vue';
+
+const uiStore = useUIStore();
 const contractsStore = useContractsStore();
 const { isDeployed, address, contract } = useContractQueries();
 const nodeStore = useNodeStore();
@@ -84,7 +86,8 @@ const isFinalityWindowValid = computed(() => {
         :showNewDeploymentButton="!isDeploymentOpen"
         @openDeployment="isDeploymentOpen = true"
       />
-      <template v-if="nodeStore.hasAtLeastOneValidator">
+
+      <template v-if="nodeStore.hasAtLeastOneValidator || uiStore.showTutorial">
         <ConstructorParameters
           id="tutorial-how-to-deploy"
           v-if="isDeploymentOpen"

--- a/frontend/test/unit/hooks/useContractListener.test.ts
+++ b/frontend/test/unit/hooks/useContractListener.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useContractListener } from '@/hooks/useContractListener';
+import { useTransactionsStore, useContractsStore } from '@/stores';
+import { useWebSocketClient } from '@/hooks';
+
+vi.mock('@/stores', () => ({
+  useTransactionsStore: vi.fn(),
+  useContractsStore: vi.fn(),
+}));
+
+vi.mock('@/hooks', () => ({
+  useWebSocketClient: vi.fn(),
+}));
+
+describe('useContractListener', () => {
+  let transactionsStoreMock: any;
+  let contractsStoreMock: any;
+  let webSocketClientMock: any;
+
+  beforeEach(() => {
+    transactionsStoreMock = {
+      getTransaction: vi.fn(),
+      removeTransaction: vi.fn(),
+      updateTransaction: vi.fn(),
+      transactions: [],
+    };
+
+    contractsStoreMock = {
+      addDeployedContract: vi.fn(),
+      contracts: [],
+      deployedContracts: [],
+    };
+
+    webSocketClientMock = {
+      on: vi.fn(),
+    };
+
+    (useTransactionsStore as any).mockReturnValue(transactionsStoreMock);
+    (useContractsStore as any).mockReturnValue(contractsStoreMock);
+    (useWebSocketClient as any).mockReturnValue(webSocketClientMock);
+  });
+
+  it('should initialize and set up websocket listener', () => {
+    const { init } = useContractListener();
+    init();
+
+    expect(webSocketClientMock.on).toHaveBeenCalledWith(
+      'deployed_contract',
+      expect.any(Function),
+    );
+  });
+
+  it('should handle deployed contract event correctly', async () => {
+    const { init } = useContractListener();
+    init();
+
+    const handleContractDeployed = webSocketClientMock.on.mock.calls.find(
+      (call: any) => call[0] === 'deployed_contract',
+    )[1];
+
+    const eventData = {
+      transaction_hash: '123',
+      data: {
+        id: 'contract_address',
+        data: { state: '{}' },
+      },
+    };
+
+    transactionsStoreMock.transactions = [
+      { hash: '123', localContractId: 'local_contract_id' },
+    ];
+
+    await handleContractDeployed(eventData);
+
+    expect(contractsStoreMock.addDeployedContract).toHaveBeenCalledWith({
+      contractId: 'local_contract_id',
+      address: 'contract_address',
+      defaultState: '{}',
+    });
+  });
+});
+


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

# What
Fixes #893 

- **Fixed deployment flow**; We were listening to a transaction event which was unreliable and moreover did not carry the contract address in its payload anymore, resulting in an error when subsequently fetching the contract abi. We are now listening to a dedicated **deployed_contract** event instead.
- **Fixed broken tutorial**: when 0 validators, some conditions in the templates were hiding the sections with contract constructor and methods, resulting in a broken tutorial. Added relevant adding exceptions in the UI to handle this edge case. Furthermore, the tutorial was broken because the mock data we were using didn't match the structure of the payloads of contracts anymore, so I update the mock data to reflect it.
- **Fixed transaction store persister race condition**: when deploying a contract, we first clear the existing transactions then add the new deploy transaction. The clear was happening after the adding, resulting in an empty tx list on reload. I made sure the order would be respected by awaiting the clear method call before adding the new transaction.

# Why
- to fix some breaking bugs

# Testing done
- tested the bug fixes

# Decisions made

- Decided to listen to **deployed_contract** event (instead of transaction status update) as a trigger to add deployed contracts in the client state.
- Added unit test for the new composable **useContractListener**.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

Try out tutorial with zero validators, and contract deployments.

# User facing release notes

- Fixed a bug with the deployment of contracts
- Fixed a bug with the tutorial tour
- Fixed a bug where deployment transactions were not persisted in state
