### PR TITLE
chore: added socketio path in jsonrpc service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       replicas: ${JSONRPC_REPLICAS:-1}
     labels:
       traefik.enable: true
-      traefik.http.routers.jsonrpc.rule: Host(`${SERVER_NAME}`) && PathPrefix(`/api`)
+      traefik.http.routers.jsonrpc.rule: Host(`${SERVER_NAME}`) && (PathPrefix(`/api`) || PathPrefix(`/socket.io`))
       traefik.http.routers.jsonrpc.entrypoints: websecure
       traefik.http.routers.jsonrpc.tls: true
 


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #N/A

# What

- Added `/socket.io` path to Traefik routing rule for jsonrpc service

# Why

- To enable WebSocket connections through the `/socket.io` endpoint
- To maintain compatibility with Socket.IO client connections

# Testing done

- Verified WebSocket connections work through Traefik
- Confirmed existing API routes continue to function

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# User facing release notes

Added WebSocket support through Socket.IO endpoint in the API service.