### PR TITLE
 chore: Pull Docker Images Instead of Building by Default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,6 @@ VALIDATORS_CONFIG_JSON = ''
 
 # Consensus mechanism
 VITE_FINALITY_WINDOW = 1800 # in seconds
+
+# Docker Image Version
+DOCKER_IMAGE_VERSION = 'latest'

--- a/.env.example
+++ b/.env.example
@@ -87,4 +87,4 @@ VALIDATORS_CONFIG_JSON = ''
 VITE_FINALITY_WINDOW = 1800 # in seconds
 
 # Docker Image Version
-DOCKER_IMAGE_VERSION = 'latest'
+STUDIO_DOCKER_IMAGE_VERSION = 'latest'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,13 @@ services:
       - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
 
   frontend:
-    # image: yeagerai/simulator-frontend:latest
+    image: yeagerai/simulator-frontend:latest
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.frontend
+      target: ${FRONTEND_BUILD_TARGET:-final}
+      args:
+        - VITE_*
     pull_policy: build
     ports:
       - "${FRONTEND_PORT}:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,6 @@ services:
       - ./.env:/app/webrequest/.env
       - ./webrequest:/app/webrequest
     environment:
-    environment:
       - FLASK_SERVER_PORT=${WEBREQUESTPORT}
       - WEBREQUESTSELENIUMPORT=${WEBREQUESTSELENIUMPORT}
       # TODO: remove this in production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   traefik:
     profiles: ["studio"]
-    image: traefik:v3.2
+    image: traefik:v3.3.3
     pull_policy: always
     ports:
       - "80:80"
@@ -12,13 +12,13 @@ services:
 
   frontend:
     image: yeagerai/simulator-frontend:latest
+    pull_policy: build
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.frontend
       target: ${FRONTEND_BUILD_TARGET:-final}
       args:
         - VITE_*
-    pull_policy: build
     ports:
       - "${FRONTEND_PORT}:8080"
     volumes:
@@ -48,8 +48,13 @@ services:
   jsonrpc:
     image: yeagerai/simulator-jsonrpc:latest
     pull_policy: always
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.backend
+      target: ${BACKEND_BUILD_TARGET:-prod}
     environment:
       - FLASK_SERVER_PORT=${RPCPORT}
+      # TODO: remove this in production
       - PYTHONUNBUFFERED=1
       - RPCDEBUGPORT=${RPCDEBUGPORT}
       - WEBREQUESTPORT=${WEBREQUESTPORT}
@@ -96,14 +101,19 @@ services:
 
   webrequest:
     image: yeagerai/simulator-webrequest:latest
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.webrequest
     pull_policy: always
     shm_size: 2gb
     volumes:
       - ./.env:/app/webrequest/.env
       - ./webrequest:/app/webrequest
     environment:
+    environment:
       - FLASK_SERVER_PORT=${WEBREQUESTPORT}
       - WEBREQUESTSELENIUMPORT=${WEBREQUESTSELENIUMPORT}
+      # TODO: remove this in production
       - PYTHONUNBUFFERED=1
     depends_on:
       ollama:
@@ -166,6 +176,9 @@ services:
   database-migration:
     image: yeagerai/simulator-database-migration:latest
     pull_policy: always
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.database-migration
     environment:
       - DB_URL=postgresql://${DBUSER}:${DBUSER}@postgres/${DBNAME}
       - WEBREQUESTPORT=${WEBREQUESTPORT}
@@ -180,6 +193,9 @@ services:
   hardhat:
     image: yeagerai/simulator-hardhat:latest
     pull_policy: always
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.hardhat
     ports:
       - "${HARDHAT_PORT:-8545}:8545"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
 
   frontend:
-    image: yeagerai/simulator-frontend:latest
+    image: yeagerai/simulator-frontend:${DOCKER_IMAGE_VERSION:-latest}
     pull_policy: build
     build:
       context: ./
@@ -46,7 +46,7 @@ services:
       traefik.http.routers.frontend.tls: true
 
   jsonrpc:
-    image: yeagerai/simulator-jsonrpc:latest
+    image: yeagerai/simulator-jsonrpc:${DOCKER_IMAGE_VERSION:-latest}
     pull_policy: always
     build:
       context: ./
@@ -100,7 +100,7 @@ services:
       traefik.http.routers.jsonrpc.tls: true
 
   webrequest:
-    image: yeagerai/simulator-webrequest:latest
+    image: yeagerai/simulator-webrequest:${DOCKER_IMAGE_VERSION:-latest}
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.webrequest
@@ -173,7 +173,7 @@ services:
      - "./data/postgres:/var/lib/postgresql/data"
 
   database-migration:
-    image: yeagerai/simulator-database-migration:latest
+    image: yeagerai/simulator-database-migration:${DOCKER_IMAGE_VERSION:-latest}
     pull_policy: always
     build:
       context: .
@@ -190,7 +190,7 @@ services:
         condition: service_healthy
 
   hardhat:
-    image: yeagerai/simulator-hardhat:latest
+    image: yeagerai/simulator-hardhat:${DOCKER_IMAGE_VERSION:-latest}
     pull_policy: always
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   traefik:
     profiles: ["studio"]
     image: traefik:v3.2
+    pull_policy: always
     ports:
       - "80:80"
       - "443:443"
@@ -9,14 +10,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
 
-
   frontend:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.frontend
-      target: ${FRONTEND_BUILD_TARGET:-final}
-      args:
-        - VITE_*
+    image: yeagerai/simulator-frontend:latest
+    pull_policy: build
     ports:
       - "${FRONTEND_PORT}:8080"
     volumes:
@@ -44,13 +40,10 @@ services:
       traefik.http.routers.frontend.tls: true
 
   jsonrpc:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.backend
-      target: ${BACKEND_BUILD_TARGET:-prod}
+    image: yeagerai/simulator-jsonpc:latest
+    pull_policy: always
     environment:
       - FLASK_SERVER_PORT=${RPCPORT}
-      # TODO: remove this in production
       - PYTHONUNBUFFERED=1
       - RPCDEBUGPORT=${RPCDEBUGPORT}
       - WEBREQUESTPORT=${WEBREQUESTPORT}
@@ -96,9 +89,8 @@ services:
       traefik.http.routers.jsonrpc.tls: true
 
   webrequest:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.webrequest
+    image: yeagerai/simulator-webrequest:latest
+    pull_policy: always
     shm_size: 2gb
     volumes:
       - ./.env:/app/webrequest/.env
@@ -106,7 +98,6 @@ services:
     environment:
       - FLASK_SERVER_PORT=${WEBREQUESTPORT}
       - WEBREQUESTSELENIUMPORT=${WEBREQUESTSELENIUMPORT}
-      # TODO: remove this in production
       - PYTHONUNBUFFERED=1
     depends_on:
       ollama:
@@ -125,6 +116,7 @@ services:
 
   ollama:
     image: ollama/ollama:0.4.1
+    pull_policy: always
     ports:
       - 11434:11434
     volumes:
@@ -142,6 +134,7 @@ services:
 
   postgres:
     image: postgres:16-alpine
+    pull_policy: always
     ports:
       - "${DBPORT}:5432"
     environment:
@@ -161,14 +154,12 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    # If you want your db to persist in dev
     volumes:
      - "./data/postgres:/var/lib/postgresql/data"
 
   database-migration:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.database-migration
+    image: yeagerai/simulator-database-migration:latest
+    pull_policy: always
     environment:
       - DB_URL=postgresql://${DBUSER}:${DBUSER}@postgres/${DBNAME}
       - WEBREQUESTPORT=${WEBREQUESTPORT}
@@ -181,9 +172,8 @@ services:
         condition: service_healthy
 
   hardhat:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.hardhat
+    image: yeagerai/simulator-hardhat:latest
+    pull_policy: always
     ports:
       - "${HARDHAT_PORT:-8545}:8545"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
 
   frontend:
-    image: yeagerai/simulator-frontend:latest
+    # image: yeagerai/simulator-frontend:latest
     pull_policy: build
     ports:
       - "${FRONTEND_PORT}:8080"
@@ -40,7 +40,7 @@ services:
       traefik.http.routers.frontend.tls: true
 
   jsonrpc:
-    image: yeagerai/simulator-jsonpc:latest
+    image: yeagerai/simulator-jsonrpc:latest
     pull_policy: always
     environment:
       - FLASK_SERVER_PORT=${RPCPORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
 
   frontend:
-    image: yeagerai/simulator-frontend:${DOCKER_IMAGE_VERSION:-latest}
+    image: yeagerai/simulator-frontend:${STUDIO_DOCKER_IMAGE_VERSION:-latest}
     pull_policy: build
     build:
       context: ./
@@ -46,7 +46,7 @@ services:
       traefik.http.routers.frontend.tls: true
 
   jsonrpc:
-    image: yeagerai/simulator-jsonrpc:${DOCKER_IMAGE_VERSION:-latest}
+    image: yeagerai/simulator-jsonrpc:${STUDIO_DOCKER_IMAGE_VERSION:-latest}
     pull_policy: always
     build:
       context: ./
@@ -100,7 +100,7 @@ services:
       traefik.http.routers.jsonrpc.tls: true
 
   webrequest:
-    image: yeagerai/simulator-webrequest:${DOCKER_IMAGE_VERSION:-latest}
+    image: yeagerai/simulator-webrequest:${STUDIO_DOCKER_IMAGE_VERSION:-latest}
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.webrequest
@@ -173,7 +173,7 @@ services:
      - "./data/postgres:/var/lib/postgresql/data"
 
   database-migration:
-    image: yeagerai/simulator-database-migration:${DOCKER_IMAGE_VERSION:-latest}
+    image: yeagerai/simulator-database-migration:${STUDIO_DOCKER_IMAGE_VERSION:-latest}
     pull_policy: always
     build:
       context: .
@@ -190,7 +190,7 @@ services:
         condition: service_healthy
 
   hardhat:
-    image: yeagerai/simulator-hardhat:${DOCKER_IMAGE_VERSION:-latest}
+    image: yeagerai/simulator-hardhat:${STUDIO_DOCKER_IMAGE_VERSION:-latest}
     pull_policy: always
     build:
       context: .


### PR DESCRIPTION
#### Pull Docker Images Instead of Building by Default

---

#### **Summary**
This PR modifies the behavior of the Docker setup by changing the default from building images locally to pulling them from a Docker Hub registry. This helps improve deployment speed, ensures consistency across environments, and reduces the complexity of managing local builds. Deployment time reduced from 15-19 minutes to ~8 minutes.

---

#### **Changes**
- Updated `docker-compose.yml`:
  - Added `image` fields for services that were previously built locally.
  - Introduced `pull_policy: always` for services to ensure they always fetch the latest image.
  - Adjusted `frontend` service to use `pull_policy: build`, allowing it to be rebuilt on each deployment.
- Updated `roles/genlayer/tasks/main.yml`:
  - Changed `build: always` to `build: policy` in `community.docker.docker_compose_v2` to align with the new behavior.

---

#### **Why This Change?**
- **Faster Deployments**: Pulling pre-built images from a registry eliminates the need to build locally every time.
- **Consistency**: Ensures that all instances use the same version of the images, preventing inconsistencies due to local environment differences.
- **Reduced Build Complexity**: Simplifies the setup for new developers and deployment environments by avoiding unnecessary local builds.

---

#### **Potential Impact**
- Developers who previously relied on local builds may need to manually trigger a rebuild if they are making changes to Docker images.
- If necessary, specific services can be overridden to allow local builds using Docker Compose overrides or by modifying `pull_policy`.

---

#### **Testing**
- Verified that the new configuration successfully pulls images instead of building them. Github actions run: https://github.com/yeagerai/genlayer-simulator-infra/actions/runs/13301335817
- Ensured that services start up correctly using the updated `docker-compose.yml`.
