### PR TITLE
chore: Pull Docker images instead of building in Production or Build them in Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,10 @@ VALIDATORS_CONFIG_JSON = ''
 
 # Consensus mechanism
 VITE_FINALITY_WINDOW = 1800 # in seconds
+
+# Docker Images for production
+STUDIO_FRONTEND_IMAGE = 'yeagerai/simulator-frontend:latest'
+STUDIO_JSONRPC_IMAGE = 'yeagerai/simulator-jsonrpc:latest'
+STUDIO_WEBREQUEST_IMAGE = 'yeagerai/simulator-webrequest:latest'
+STUDIO_DATABASE_MIGRATION_IMAGE = 'yeagerai/simulator-database-migration:latest'
+STUDIO_HARDHAT_IMAGE = 'yeagerai/simulator-hardhat:latest'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,32 @@
+# Usage in dev:
+# docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+
+services:
+  frontend:
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.frontend
+      target: ${FRONTEND_BUILD_TARGET:-final}
+      args:
+        - VITE_*
+
+  jsonrpc:
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.backend
+      target: ${BACKEND_BUILD_TARGET:-prod}
+  
+  webrequest:
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.webrequest
+
+  database-migration:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.database-migration
+
+  hardhat:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.hardhat

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,24 @@
+# Usage in prod:
+# docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+# docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+services:
+  frontend:
+    build: # https://github.com/yeagerai/genlayer-simulator-infra/issues/72#issuecomment-2626876413
+      context: ./
+      dockerfile: ./docker/Dockerfile.frontend
+      target: ${FRONTEND_BUILD_TARGET:-final}
+      args:
+        - VITE_*
+
+  jsonrpc:
+    image: ${STUDIO_JSONRPC_IMAGE:-yeagerai/simulator-jsonrpc:latest}
+  
+  webrequest:
+    image: ${STUDIO_WEBREQUEST_IMAGE:-yeagerai/simulator-webrequest:latest}
+
+  database-migration:
+    image: ${STUDIO_DATABASE_MIGRATION_IMAGE:-yeagerai/simulator-database-migration:latest}
+
+  hardhat:
+    image: ${STUDIO_HARDHAT_IMAGE:-yeagerai/simulator-hardhat:latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,6 @@ services:
       - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
 
   frontend:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.frontend
-      target: ${FRONTEND_BUILD_TARGET:-final}
-      args:
-        - VITE_*
     ports:
       - "${FRONTEND_PORT}:8080"
     volumes:
@@ -43,10 +37,6 @@ services:
       traefik.http.routers.frontend.tls: true
 
   jsonrpc:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.backend
-      target: ${BACKEND_BUILD_TARGET:-prod}
     environment:
       - FLASK_SERVER_PORT=${RPCPORT}
       # TODO: remove this in production
@@ -95,9 +85,6 @@ services:
       traefik.http.routers.jsonrpc.tls: true
 
   webrequest:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.webrequest
     shm_size: 2gb
     volumes:
       - ./.env:/app/webrequest/.env
@@ -165,9 +152,6 @@ services:
      - "./data/postgres:/var/lib/postgresql/data"
 
   database-migration:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.database-migration
     environment:
       - DB_URL=postgresql://${DBUSER}:${DBUSER}@postgres/${DBNAME}
       - WEBREQUESTPORT=${WEBREQUESTPORT}
@@ -180,9 +164,6 @@ services:
         condition: service_healthy
 
   hardhat:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.hardhat
     ports:
       - "${HARDHAT_PORT:-8545}:8545"
     volumes:


### PR DESCRIPTION
# What

- Added new environment variables in `.env.example` to define production Docker images.
- Introduced `docker-compose.prod.yml` to use pre-built Docker images instead of building them.
- Created `docker-compose.dev.yml` to keep build instructions for local development.
- Updated `docker-compose.prod.yml` to reference pre-built images using `STUDIO_*` environment variables.
- Ensured that the production setup pulls images rather than building them.

# Why

- Optimizing production deployments by pulling pre-built Docker images rather than rebuilding them on each deployment.
- Reducing build times and ensuring consistency across environments.
- Keeping development and production workflows separate to improve maintainability.

# Testing done

- Verified that `docker-compose.prod.yml` successfully pulls the expected images.
- Ensured that `docker-compose.dev.yml` still allows building from source for local development.
- Manually tested service startup with `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d`.

# Decisions made

- Chose to explicitly define images in `.env.example` to allow overrides in production.
- Separated development (`docker-compose.dev.yml`) and production (`docker-compose.prod.yml`) configurations to improve clarity.
- Kept the `frontend` service as a build step in production due to potential need for custom configurations.

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [x] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the changes in `docker-compose.prod.yml` to confirm the image pull behavior.
- Ensure that the separation of dev and prod configurations makes sense.
- Double-check that the `.env.example` updates align with the new workflow.

# User-facing release notes

- **Production deployments now pull pre-built Docker images instead of building them.**
- **New `.env.example` variables allow for easy customization of image versions.**
- **Development workflows remain unchanged, with the ability to build images locally.**