### PR TITLE
feat: add config for rotation rounds per tx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,4 @@ VALIDATORS_CONFIG_JSON = ''
 
 # Consensus mechanism
 VITE_FINALITY_WINDOW = 1800 # in seconds
+VITE_MAX_ROTATIONS = 3

--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -16,7 +16,6 @@ from web3 import Web3
 from backend.database_handler.contract_snapshot import ContractSnapshot
 import os
 from sqlalchemy.orm.attributes import flag_modified
-from backend.domain.types import MAX_ROTATIONS
 
 from backend.rollup.consensus_service import ConsensusService
 
@@ -137,6 +136,7 @@ class TransactionsProcessor:
         type: int,
         nonce: int,
         leader_only: bool,
+        config_rotation_rounds: int,
         triggered_by_hash: (
             str | None
         ) = None,  # If filled, the transaction must be present in the database (committed)
@@ -186,7 +186,7 @@ class TransactionsProcessor:
             timestamp_appeal=None,
             appeal_processing_time=0,
             contract_snapshot=None,
-            config_rotation_rounds=MAX_ROTATIONS,
+            config_rotation_rounds=config_rotation_rounds,
         )
 
         self.session.add(new_transaction)

--- a/backend/domain/types.py
+++ b/backend/domain/types.py
@@ -5,12 +5,11 @@
 from dataclasses import dataclass, field
 import decimal
 from enum import Enum, IntEnum
+import os
 
 from backend.database_handler.models import TransactionStatus
 from backend.database_handler.types import ConsensusData
 from backend.database_handler.contract_snapshot import ContractSnapshot
-
-MAX_ROTATIONS = 3
 
 
 @dataclass()
@@ -93,7 +92,7 @@ class Transaction:
     timestamp_appeal: int | None = None
     appeal_processing_time: int = 0
     contract_snapshot: ContractSnapshot | None = None
-    config_rotation_rounds: int | None = MAX_ROTATIONS
+    config_rotation_rounds: int | None = int(os.getenv("VITE_MAX_ROTATIONS", 3))
 
     def to_dict(self):
         return {

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -533,6 +533,7 @@ def send_raw_transaction(
         genlayer_transaction.type.value,
         nonce,
         leader_only,
+        genlayer_transaction.max_rotations,
     )
     consensus_service.forward_transaction(signed_rollup_transaction)
 

--- a/backend/protocol_rpc/transactions_parser.py
+++ b/backend/protocol_rpc/transactions_parser.py
@@ -200,6 +200,7 @@ class TransactionParser:
 
         sender = rollup_transaction.data.args.sender
         recipient = rollup_transaction.data.args.recipient
+        max_rotations = rollup_transaction.data.args.max_rotations
         type = self._get_genlayer_transaction_type(recipient)
         data = self._get_genlayer_transaction_data(type, rollup_transaction.data.args)
 
@@ -207,6 +208,7 @@ class TransactionParser:
             from_address=sender,
             to_address=recipient,
             type=type,
+            max_rotations=max_rotations,
             data=DecodedGenlayerTransactionData(
                 contract_code=(
                     data.contract_code if hasattr(data, "contract_code") else None

--- a/backend/protocol_rpc/types.py
+++ b/backend/protocol_rpc/types.py
@@ -83,3 +83,4 @@ class DecodedGenlayerTransaction:
     to_address: str
     data: DecodedGenlayerTransactionData
     type: TransactionType
+    max_rotations: int

--- a/frontend/src/components/Simulator/ConstructorParameters.vue
+++ b/frontend/src/components/Simulator/ConstructorParameters.vue
@@ -8,6 +8,7 @@ import { type ArgData, unfoldArgsData } from './ContractParams';
 
 const props = defineProps<{
   leaderOnly: boolean;
+  consensusMaxRotations: number;
 }>();
 
 const { contract, contractSchemaQuery, deployContract, isDeploying } =
@@ -24,7 +25,7 @@ const emit = defineEmits(['deployed-contract']);
 const handleDeployContract = async () => {
   const args = calldataArguments.value;
   const newArgs = unfoldArgsData(args);
-  await deployContract(newArgs, props.leaderOnly);
+  await deployContract(newArgs, props.leaderOnly, props.consensusMaxRotations);
 
   emit('deployed-contract');
 };

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
   method: ContractMethod;
   methodType: 'read' | 'write';
   leaderOnly: boolean;
+  consensusMaxRotations?: number;
 }>();
 
 const isExpanded = ref(false);
@@ -84,6 +85,7 @@ const handleCallWriteMethod = async () => {
     await callWriteMethod({
       method: props.name,
       leaderOnly: props.leaderOnly,
+      consensusMaxRotations: props.consensusMaxRotations,
       args: unfoldArgsData({
         args: calldataArguments.value.args,
         kwargs: calldataArguments.value.kwargs,

--- a/frontend/src/components/Simulator/ContractWriteMethods.vue
+++ b/frontend/src/components/Simulator/ContractWriteMethods.vue
@@ -7,6 +7,7 @@ import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vu
 import type { ContractSchema } from 'genlayer-js/types';
 const props = defineProps<{
   leaderOnly: boolean;
+  consensusMaxRotations: number;
 }>();
 
 const { contractAbiQuery } = useContractQueries();
@@ -41,6 +42,7 @@ const writeMethods = computed(() => {
         :method="method[1]"
         methodType="write"
         :leaderOnly="props.leaderOnly"
+        :consensusMaxRotations="consensusMaxRotations"
       />
 
       <EmptyListPlaceholder v-if="writeMethods.length === 0">

--- a/frontend/src/components/Simulator/settings/ConsensusSection.vue
+++ b/frontend/src/components/Simulator/settings/ConsensusSection.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import PageSection from '@/components/Simulator/PageSection.vue';
+import FieldError from '@/components/global/fields/FieldError.vue';
+import NumberInput from '@/components/global/inputs/NumberInput.vue';
+import { useConsensusStore } from '@/stores';
+
+const consensusStore = useConsensusStore();
+const maxRotations = computed({
+  get: () => consensusStore.maxRotations,
+  set: (newTime) => {
+    if (isMaxRotationsValid(newTime)) {
+      consensusStore.setMaxRotations(newTime);
+    }
+  },
+});
+
+function isMaxRotationsValid(value: number) {
+  return Number.isInteger(value) && value >= 0;
+}
+</script>
+
+<template>
+  <PageSection>
+    <template #title>Consensus</template>
+
+    <div class="p-2">
+      <div class="flex flex-wrap items-center gap-2">
+        <label for="maxRotations" class="text-xs">Max Rotations</label>
+        <NumberInput
+          id="maxRotations"
+          name="maxRotations"
+          :min="0"
+          :step="1"
+          v-model.number="maxRotations"
+          required
+          testId="input-maxRotations"
+          :disabled="false"
+          class="h-6 w-12"
+          tiny
+        />
+      </div>
+
+      <FieldError v-if="!isMaxRotationsValid"
+        >Please enter a positive integer.</FieldError
+      >
+    </div>
+  </PageSection>
+</template>

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -98,6 +98,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     },
     leaderOnly: boolean,
+    consensusMaxRotations: number,
   ) {
     isDeploying.value = true;
 
@@ -113,6 +114,7 @@ export function useContractQueries() {
         code: code_bytes as any as string, // FIXME: code should accept both bytes and string in genlayer-js
         args: args.args,
         leaderOnly,
+        consensusMaxRotations,
       });
 
       const tx: TransactionItem = {
@@ -203,6 +205,7 @@ export function useContractQueries() {
     method,
     args,
     leaderOnly,
+    consensusMaxRotations,
   }: {
     method: string;
     args: {
@@ -210,6 +213,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     };
     leaderOnly: boolean;
+    consensusMaxRotations: number;
   }) {
     try {
       if (!accountsStore.selectedAccount) {
@@ -222,6 +226,7 @@ export function useContractQueries() {
         args: args.args,
         value: BigInt(0),
         leaderOnly,
+        consensusMaxRotations,
       });
 
       transactionsStore.addTransaction({

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -7,6 +7,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
   const webSocketClient = useWebSocketClient();
   const finalityWindow = ref(Number(import.meta.env.VITE_FINALITY_WINDOW));
   const isLoading = ref<boolean>(true); // Needed for the delay between creating the variable and fetching the initial value
+  const maxRotations = ref(Number(import.meta.env.VITE_MAX_ROTATIONS));
 
   if (!webSocketClient.connected) webSocketClient.connect();
 
@@ -34,10 +35,16 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     finalityWindow.value = time;
   }
 
+  function setMaxRotations(rotations: number) {
+    maxRotations.value = rotations;
+  }
+
   return {
     finalityWindow,
     setFinalityWindowTime,
     fetchFinalityWindowTime,
     isLoading,
+    maxRotations,
+    setMaxRotations,
   };
 });

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -50,6 +50,8 @@ watch(
 function isFinalityWindowValid(value: number) {
   return Number.isInteger(value) && value >= 0;
 }
+
+const consensusMaxRotations = computed(() => consensusStore.maxRotations);
 </script>
 
 <template>
@@ -104,6 +106,7 @@ function isFinalityWindowValid(value: number) {
           v-if="isDeploymentOpen"
           @deployedContract="isDeploymentOpen = false"
           :leaderOnly="leaderOnly"
+          :consensusMaxRotations="consensusMaxRotations"
         />
 
         <ContractReadMethods
@@ -115,6 +118,7 @@ function isFinalityWindowValid(value: number) {
           v-if="isDeployed"
           id="tutorial-write-methods"
           :leaderOnly="leaderOnly"
+          :consensusMaxRotations="consensusMaxRotations"
         />
         <TransactionsList
           id="tutorial-tx-response"

--- a/frontend/src/views/Simulator/SettingsView.vue
+++ b/frontend/src/views/Simulator/SettingsView.vue
@@ -2,6 +2,7 @@
 import { useConfig } from '@/hooks';
 import MainTitle from '@/components/Simulator/MainTitle.vue';
 import ProviderSection from '@/components/Simulator/settings/ProviderSection.vue';
+import ConsensusSection from '@/components/Simulator/settings/ConsensusSection.vue';
 import SimulatorSection from '@/components/Simulator/settings/SimulatorSection.vue';
 
 const { canUpdateProviders } = useConfig();
@@ -12,6 +13,7 @@ const { canUpdateProviders } = useConfig();
     <MainTitle data-testid="settings-page-title">Settings</MainTitle>
 
     <SimulatorSection />
+    <ConsensusSection />
     <ProviderSection v-if="canUpdateProviders" />
   </div>
 </template>


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #827 

# What

<!-- Describe the changes you made. -->

- Added number field for maximum number of leader rotations per transaction in settings tab.
- Added passing the max rotations from the frontend to genlayer-js.
- Added passing the max rotations from the rpc method to the insert_transaction function.
- Added environment variable VITE_MAX_ROTATIONS @epsjunior.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- The user can set the maximum number of leader rotations.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the new feature in UI.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->


# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Check code changes, run in UI (put majority_agrees = False in base.py to trigger rotations).

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
- The user can set the maximum number of leader rotations.