### PR TITLE
feat: bypass non implemented eth methods to hardhat node

### DIFF
--- a/backend/protocol_rpc/server.py
+++ b/backend/protocol_rpc/server.py
@@ -15,6 +15,7 @@ from backend.database_handler.llm_providers import LLMProviderRegistry
 from backend.protocol_rpc.configuration import GlobalConfiguration
 from backend.protocol_rpc.message_handler.base import MessageHandler
 from backend.protocol_rpc.endpoints import register_all_rpc_endpoints
+from backend.protocol_rpc.endpoint_generator import setup_eth_method_handler
 from backend.protocol_rpc.validators_init import initialize_validators
 from backend.protocol_rpc.transactions_parser import TransactionParser
 from dotenv import load_dotenv
@@ -54,6 +55,7 @@ def create_app():
     jsonrpc = JSONRPC(
         app, "/api", enable_web_browsable_api=True
     )  # check it out at http://localhost:4000/api/browse/#/
+    setup_eth_method_handler(jsonrpc)
     socketio = SocketIO(app, cors_allowed_origins="*")
     # Handlers
     msg_handler = MessageHandler(socketio, config=GlobalConfiguration())


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #830 

# What

<!-- Describe the changes you made. -->

- Implemented a new function `setup_eth_method_handler` in `endpoint_generator.py` to forward `eth_` methods to Hardhat if no local implementation is available.
- Integrated the `setup_eth_method_handler` function into the application setup in `server.py`.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To enable the forwarding of Ethereum JSON-RPC methods to a Hardhat node when they are not implemented locally, enhancing the flexibility and capability of the application.
- This change allows us to leverage Hardhat's features without needing to implement every `eth_` method locally, thus saving time and effort.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified that `eth_` methods are correctly forwarded to the Hardhat node when not implemented locally.
- Results for not implemented eth_ method:
   - Before this PR: `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' http://localhost:4000/api` returned `{"error":{"code":-32601,"data":{"message":"Method not found: eth_accounts"},"message":"Method not found","name":"MethodNotFoundError"},"id":1,"jsonrpc":"2.0"}`.
   - After this PR: `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' http://localhost:4000/api` returns `{"id":1,"jsonrpc":"2.0","result":["0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","0x70997970c51812dc3a010c7d01b50e0d17dc79c8","0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc","0x90f79bf6eb2c4f870365e785982e1f101e93b906","0x15d34aaf54267db7d7c367839aaf71a00a2c6a65","0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc","0x976ea74026e726554db657fa54763abd0c3a0aa9","0x14dc79964da2c08b23698b3d3cc7ca32193d9955","0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f","0xa0ee7a142d267c1f36714e4a8f75612f20a79720","0xbcd4042de499d14e55001ccbb24a551f3b954096","0x71be63f3384f5fb98995898a86b02fb2426c5788","0xfabb0ac9d68b0b445fb7357272ff202c5651694a","0x1cbd3b2770909d4e10f157cabc84c7264073c9ec","0xdf3e18d64bc6a983f673ab319ccae4f1a57c7097","0xcd3b766ccdd6ae721141f452c550ca635964ce71","0x2546bcd3c84621e976d8185a91a922ae77ecec30","0xbda5747bfd65f08deb54cb465eb87d40e51b197e","0xdd2fd4581271e230360230f9337d5c0430bf44c0","0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199"]}`.
- Results for implemented methods:
   - `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:4000/api` returns `{"id":1,"jsonrpc":"2.0","result":"0x67be35a0"}`
   - `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"sim_countValidators","params":[],"id":1}' http://localhost:4000/api` returns `{"id":1,"jsonrpc":"2.0","result":7}`

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->
- I have tried to catch the MethodNotFoundError to filter but that did not work so before_request solved it.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the integration of the `setup_eth_method_handler` function and its impact on the existing application flow.
- Review the error handling logic to ensure robustness in various failure scenarios.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Added support for forwarding Ethereum JSON-RPC methods to a Hardhat node when not implemented locally.