### PR TITLE
feat: return genvm and studio versions from gen_protocolVersion endpoint

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -726,6 +726,27 @@ def get_contract(consensus_service: ConsensusService, contract_name: str) -> dic
     }
 
 
+def get_genvm_version() -> dict:
+    """
+    return dict of version information for genvm and studio
+    """
+    try:
+        with open("/app/shared/genvm_version.txt") as fh:
+            genvm_version = fh.read().strip()
+    except FileNotFoundError:
+        genvm_version = "unknown"
+
+    try:
+        with open("/app/shared/studio_version.txt") as fh:
+            studio_version = fh.read().strip()
+    except FileNotFoundError:
+        studio_version = "unknown"
+
+    versioning = {"genvm_version": genvm_version, "studio_version": studio_version}
+
+    return versioning
+
+
 def register_all_rpc_endpoints(
     jsonrpc: JSONRPC,
     msg_handler: MessageHandler,
@@ -894,4 +915,8 @@ def register_all_rpc_endpoints(
     register_rpc_endpoint(
         partial(get_block_by_hash, transactions_processor),
         method_name="eth_getBlockByHash",
+    )
+    register_rpc_endpoint(
+        partial(get_genvm_version),
+        method_name="gen_protocolVersion",
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - ./examples:/app/src/assets/examples
       - ./frontend/src:/app/src
+      - shared_data:/app/shared
     depends_on:
       jsonrpc:
         condition: service_healthy
@@ -63,6 +64,7 @@ services:
       - ./backend:/app/backend
       - hardhat_artifacts:/app/hardhat/artifacts
       - hardhat_deployments:/app/hardhat/deployments
+      - shared_data:/app/shared
     depends_on:
       hardhat:
         condition: service_healthy
@@ -215,3 +217,4 @@ volumes:
   hardhat_cache:
   hardhat_deployments:
   ignition_deployments:
+  shared_data:

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -29,6 +29,7 @@ RUN groupadd -r backend-group \
     && chown -R backend-user:backend-group /home/backend-user \
     && chown -R backend-user:backend-group $path \
     && mkdir -p /genvm
+RUN mkdir -p $path/shared
 
 ENV PYTHONPATH "${PYTHONPATH}:/${path}"
 ENV FLASK_APP backend/protocol_rpc/server.py
@@ -62,6 +63,7 @@ RUN cd /genvm \
 RUN su - backend-user -c '/genvm/bin/genvm precompile'
 
 COPY ../.env .
+RUN echo "$GENVM_TAG" > $path/shared/genvm_version.txt
 COPY backend $path/backend
 
 HEALTHCHECK --interval=1s --timeout=1s --retries=30 --start-period=3s CMD python3 backend/healthcheck.py --port ${FLASK_SERVER_PORT}

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -8,19 +8,23 @@ COPY ./examples src/assets/examples
 COPY ./.env ./.env
 COPY ../backend/node/create_nodes/providers_schema.json /app/src/assets/schemas/providers_schema.json
 
+RUN apk add --no-cache jq \
+    && mkdir -p /app/shared /app/tmp \
+    && chmod -R 777 /app/shared /app/tmp \
+    && jq -r '.version' package.json > /app/tmp/studio_version.txt
 
 FROM base AS dev
-ENTRYPOINT ["npm", "run", "dev"]
+ENTRYPOINT sh -c "cp -r /app/tmp/studio_version.txt /app/shared/studio_version.txt && rm -rf /app/tmp && npm run dev"
 
 FROM base AS builder
 RUN npm run build
 
 FROM alpine:latest AS final
 RUN apk add --no-cache nodejs npm && \
-    addgroup --system frontend-user && adduser --system --ingroup frontend-user frontend-user && \
+    addgroup --system frontend-user && adduser --system --ingroup  frontend-user --shell /bin/sh frontend-user && \
     mkdir /app && chown -R frontend-user:frontend-user /app
 WORKDIR /app
 COPY --from=builder --chown=frontend-user:frontend-user /app /app
-USER frontend-user
+
 EXPOSE 8080
-CMD [ "npm", "run", "preview" ]
+CMD sh -c "cp -r /app/tmp/studio_version.txt /app/shared/studio_version.txt && rm -rf /app/tmp && su -s /bin/sh frontend-user -c 'npm run preview'"

--- a/tests/common/request.py
+++ b/tests/common/request.py
@@ -83,6 +83,13 @@ def call_contract_method(
     return result
 
 
+async def get_gen_protocol_version():
+    payload_data = payload("gen_protocolVersion")
+    raw_response = post_request_localhost(payload_data)
+    parsed_raw_response = raw_response.json()
+    return parsed_raw_response
+
+
 def _prepare_transaction(
     account: Account,
     recipient_address: str | None,

--- a/tests/integration/deploy/test_deploy.py
+++ b/tests/integration/deploy/test_deploy.py
@@ -2,12 +2,13 @@ from pathlib import Path
 import zipfile
 import io
 import base64
-
+import pytest
 from tests.common.request import (
     deploy_intelligent_contract,
     write_intelligent_contract,
     payload,
     post_request_localhost,
+    get_gen_protocol_version,
 )
 
 from tests.common.response import (
@@ -45,3 +46,16 @@ def test_deploy(setup_validators, from_account):
     res = call_contract_method(contract_address, from_account, "test", [])
 
     assert res == "123"
+
+
+@pytest.mark.asyncio
+async def test_get_current_gen_protocol_version():
+    get_versions = await get_gen_protocol_version()
+    result = get_versions["result"]
+
+    assert isinstance(result, dict), "Result should be a dict"
+    assert "genvm_version" in result
+    assert "studio_version" in result
+
+    assert result.get("genvm_version") not in ["unknown", "", None]
+    assert result.get("studio_version") not in ["unknown", "", None]


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #issue-number-here

# What

<!-- Describe the changes you made. -->

- added a gen_protocolVersion rpc endpoint that reads version of genvm and studio from backend docker image and frontend package config
- modified dockerfile to capture the versions during build in a shared_data volume

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to allow easy view and tracking of what versions of genvm and studio are used 

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- rpc integration test to verify the both versions of genvm and studio exists for every build of the software

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->
- Having a shared_data volume allows the backend rpc endpoint capture the version of the systems in use 

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
