### PR TITLE
fix: appeals bug leader appeal no validators check

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -991,9 +991,16 @@ class ConsensusAlgorithm:
         transactions_processor.set_transaction_appeal(transaction.hash, False)
         transaction.appealed = False
 
-        if len(transaction.consensus_data.validators) + 1 == len(
-            chain_snapshot.get_all_validators()
-        ):
+        used_leader_addresses = (
+            ConsensusAlgorithm.get_used_leader_addresses_from_consensus_history(
+                context.transactions_processor.get_transaction_by_hash(
+                    context.transaction.hash
+                )["consensus_history"]
+            )
+        )
+        if len(transaction.consensus_data.validators) + len(
+            used_leader_addresses
+        ) >= len(chain_snapshot.get_all_validators()):
             self.msg_handler.send_message(
                 LogEvent(
                     "consensus_event",


### PR DESCRIPTION
Fixes #969 

# What

- Updated the logic in `ConsensusAlgorithm` to correctly count used leaders in the consensus check.

# Why

- To fix a bug where the consensus check did not account for used leaders so the error is not caught.

# Testing done

- Verified that the updated condition correctly counts both validators and used leaders in UI.

# Decisions made

- Decided to use the `get_used_leader_addresses_from_consensus_history` method to retrieve used leader addresses, as it provides a reliable way to access this information from the transaction's consensus history.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Pay attention to the logic change in the consensus check condition to ensure it aligns with the intended behavior.

# User facing release notes

- Fixed an issue in the consensus algorithm where used leaders were not counted in the consensus check.