### PR TITLE
fix: appeal leader appeal uses wrong contractsnapshot

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -11,6 +11,7 @@ import time
 from abc import ABC, abstractmethod
 import threading
 import random
+from copy import deepcopy
 
 from sqlalchemy.orm import Session
 from backend.consensus.vrf import get_validators_for_transaction
@@ -1034,6 +1035,12 @@ class ConsensusAlgorithm:
             )
             transaction.appeal_undetermined = True
 
+            context.contract_snapshot_supplier = (
+                lambda: context.contract_snapshot_factory(
+                    context.transaction.to_address
+                )
+            )
+
             # Begin state transitions starting from PendingState
             state = PendingState()
             while True:
@@ -1597,16 +1604,21 @@ class ProposingState(TransactionState):
         if context.transaction.leader_only:
             context.remaining_validators = []
 
-        # Create a contract snapshot for the transaction
-        contract_snapshot_supplier = lambda: context.contract_snapshot_factory(
-            context.transaction.to_address
-        )
+        # Create a contract snapshot for the transaction if not exists
+        if context.transaction.contract_snapshot:
+            contract_snapshot = deepcopy(context.transaction.contract_snapshot)
+        else:
+            contract_snapshot_supplier = lambda: context.contract_snapshot_factory(
+                context.transaction.to_address
+            )
+            context.contract_snapshot_supplier = contract_snapshot_supplier
+            contract_snapshot = contract_snapshot_supplier()
 
         # Create a leader node for executing the transaction
         leader_node = context.node_factory(
             leader,
             ExecutionMode.LEADER,
-            contract_snapshot_supplier(),
+            contract_snapshot,
             None,
             context.msg_handler,
             context.contract_snapshot_factory,
@@ -1626,7 +1638,6 @@ class ProposingState(TransactionState):
 
         # Set the validators and other context attributes
         context.num_validators = len(context.remaining_validators) + 1
-        context.contract_snapshot_supplier = contract_snapshot_supplier
         context.votes = votes
 
         # Transition to the CommittingState
@@ -1991,9 +2002,10 @@ class AcceptedState(TransactionState):
             leaders_contract_snapshot = context.contract_snapshot_supplier()
 
             # Set the contract snapshot for the transaction for a future rollback
-            context.transactions_processor.set_transaction_contract_snapshot(
-                context.transaction.hash, leaders_contract_snapshot.to_dict()
-            )
+            if not context.transaction.contract_snapshot:
+                context.transactions_processor.set_transaction_contract_snapshot(
+                    context.transaction.hash, leaders_contract_snapshot.to_dict()
+                )
 
             # Do not deploy or update the contract if the execution failed
             if leader_receipt.execution_result == ExecutionResultStatus.SUCCESS:
@@ -2092,6 +2104,12 @@ class UndeterminedState(TransactionState):
             consensus_round = "Leader Appeal Failed"
         else:
             consensus_round = "Undetermined"
+
+        # Save the contract snapshot for potential future appeals
+        if not context.transaction.contract_snapshot:
+            context.transactions_processor.set_transaction_contract_snapshot(
+                context.transaction.hash, context.contract_snapshot_supplier().to_dict()
+            )
 
         # Set the transaction result with the current consensus data
         context.transactions_processor.set_transaction_result(


### PR DESCRIPTION
Fixes #981 

# What

- Updated the `ConsensusAlgorithm` and various `TransactionState` classes to use a stored contract snapshot for leader appeals.
- Introduced a check to determine if a contract snapshot is already stored before creating a new one.
- Utilized `deepcopy` to ensure the integrity of the contract snapshot when it already exists. So that a validator does not use a modified version.
- Added logic to save the contract snapshot for potential future appeals.

# Why

- To fix a bug where leader appeals were not using the stored contract snapshot, which led to inconsistencies in transaction processing.

# Testing done

- Verified that the system correctly uses the stored contract snapshot during leader appeals in UI.

# Decisions made

- Decided to use `deepcopy` for existing contract snapshots to prevent unintended modifications.
- Chose to conditionally set the contract snapshot supplier only when necessary to avoid redundant operations.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the changes related to contract snapshot handling in the `ConsensusAlgorithm` and `TransactionState` classes.
- Pay attention to the conditions under which the contract snapshot is created or reused.

# User facing release notes

- Fixed an issue where leader appeals did not use the stored contract snapshot.