### PR TITLE
feat: cursor add MCP server file for postgres db

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--network=host",
+        "mcp/postgres",
+        "postgresql://postgres:postgres@host.docker.internal:5432/genlayer_state"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #1023 

# What

<!-- Describe the changes you made. -->

- Added a new configuration file `.cursor/mcp.json` to the project.
- This file defines an MCP server configuration for PostgreSQL using Docker.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To enable easy setup and management of a PostgreSQL server using Docker.
- This change facilitates development and testing by providing a consistent environment.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified that the Docker command specified in the configuration runs successfully.
- Ensured that the PostgreSQL server is accessible and operational as expected.
- Performed a cursor prompt to access the database:
<img width="504" alt="Screenshot 2025-03-25 at 17 29 49" src="https://github.com/user-attachments/assets/c4885d0d-e3db-46b1-8e8d-73b31348530d" />


# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Decided to use Docker for managing the PostgreSQL server to leverage containerization benefits.
- Chose to use the `host` network mode for simplicity in accessing the database.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
- Go to Cursor Settings -> MCP and see if it is running (green circle).
- Review the `.cursor/mcp.json` file for correct Docker command syntax and parameters.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Added a new configuration for setting up an MCP PostgreSQL server to connect to via cursor.