### PR TITLE
feat: adjust value in current_state based on transaction values

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -17,6 +17,7 @@ from backend.database_handler.contract_snapshot import ContractSnapshot
 import os
 from sqlalchemy.orm.attributes import flag_modified
 from backend.domain.types import MAX_ROTATIONS
+from backend.database_handler.accounts_manager import AccountsManager
 
 from backend.rollup.consensus_service import ConsensusService
 
@@ -181,7 +182,16 @@ class TransactionsProcessor:
         triggered_by_hash: (
             str | None
         ) = None,  # If filled, the transaction must be present in the database (committed)
+        accounts_manager: AccountsManager | None = None,
     ) -> str:
+        if accounts_manager:
+            sender_balance = accounts_manager.get_account_balance(from_address)
+
+            if sender_balance < value:
+                raise ValueError(
+                    f"Sender has insufficient balance. Is {sender_balance}, needs {value}"
+                )
+
         current_nonce = self.get_transaction_count(from_address)
 
         # Follow up: https://github.com/MetaMask/metamask-extension/issues/29787

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -124,6 +124,7 @@ class Node:
                 transaction.from_address,
                 calldata,
                 transaction.hash,
+                transaction.value,
                 transaction.created_at,
             )
         else:
@@ -180,6 +181,7 @@ class Node:
         from_address: str,
         calldata: bytes,
         transaction_hash: str,
+        transaction_value: int,
         transaction_created_at: str | None = None,
     ) -> Receipt:
         return await self._run_genvm(
@@ -189,6 +191,7 @@ class Node:
             is_init=False,
             transaction_hash=transaction_hash,
             transaction_datetime=self._date_from_str(transaction_created_at),
+            transaction_value=transaction_value,
         )
 
     async def get_contract_data(
@@ -262,6 +265,7 @@ class Node:
         is_init: bool,
         transaction_hash: str | None = None,
         transaction_datetime: datetime.datetime | None,
+        transaction_value: int | None = None,
     ) -> Receipt:
         genvm = self._create_genvm()
         leader_res: None | dict[int, bytes]
@@ -310,6 +314,7 @@ class Node:
             config=json.dumps(config),
             date=transaction_datetime,
             chain_id=SIMULATOR_CHAIN_ID,
+            value=transaction_value,
         )
         await self._execution_finished(res, transaction_hash)
 

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -99,6 +99,7 @@ class IGenVM(typing.Protocol):
         config: str,
         date: datetime.datetime | None,
         chain_id: int,
+        value: int | None,
     ) -> ExecutionResult: ...
 
     async def get_contract_schema(self, contract_code: bytes) -> ExecutionResult: ...
@@ -149,13 +150,14 @@ class GenVMHost(IGenVM):
         config: str,
         date: datetime.datetime | None,
         chain_id: int,
+        value: int | None,
     ) -> ExecutionResult:
         message = {
             "is_init": is_init,
             "contract_address": contract_address.as_b64,
             "sender_address": from_address.as_b64,
             "origin_address": from_address.as_b64,  # FIXME: no origin in simulator #751
-            "value": None,
+            "value": value,
             "chain_id": str(
                 chain_id
             ),  # NOTE: it can overflow u64 so better to wrap it into a string

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -525,15 +525,23 @@ def send_raw_transaction(
         transaction_data = {"calldata": genlayer_transaction.data.calldata}
 
     # Insert transaction into the database
-    transaction_hash = transactions_processor.insert_transaction(
-        genlayer_transaction.from_address,
-        to_address,
-        transaction_data,
-        value,
-        genlayer_transaction.type.value,
-        nonce,
-        leader_only,
-    )
+    try:
+        transaction_hash = transactions_processor.insert_transaction(
+            genlayer_transaction.from_address,
+            to_address,
+            transaction_data,
+            value,
+            genlayer_transaction.type.value,
+            nonce,
+            leader_only,
+            None,
+            accounts_manager,
+        )
+    except ValueError as e:
+        raise JSONRPCError(
+            message=str(e),
+            data={"sender_address": genlayer_transaction.from_address},
+        )
     consensus_service.forward_transaction(signed_rollup_transaction)
 
     return transaction_hash

--- a/frontend/src/components/Simulator/AccountSelect.vue
+++ b/frontend/src/components/Simulator/AccountSelect.vue
@@ -16,16 +16,14 @@ const hasMetaMaskAccount = computed(() =>
 );
 
 const handleCreateNewAccount = async () => {
-  const address = store.generateNewAccount();
-
-  if (address) {
+  try {
+    const account = await store.generateNewAccount();
     notify({
       title: 'New Account Created',
       type: 'success',
     });
-
     trackEvent('created_account');
-  } else {
+  } catch (error) {
     notify({
       title: 'Error creating a new account',
       type: 'error',

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -5,12 +5,13 @@ import { ref } from 'vue';
 import { Collapse } from 'vue-collapsed';
 import { notify } from '@kyvg/vue3-notification';
 import { ChevronDownIcon } from '@heroicons/vue/16/solid';
-import { useEventTracking, useContractQueries } from '@/hooks';
+import { useEventTracking, useContractQueries, useInputMap } from '@/hooks';
 import { unfoldArgsData, type ArgData } from './ContractParams';
 import ContractParams from './ContractParams.vue';
 
 const { callWriteMethod, callReadMethod, contract } = useContractQueries();
 const { trackEvent } = useEventTracking();
+const inputMap = useInputMap();
 
 const props = defineProps<{
   name: string;
@@ -24,6 +25,11 @@ const isCalling = ref(false);
 const responseMessage = ref();
 
 const calldataArguments = ref<ArgData>({ args: [], kwargs: {} });
+const value = ref<bigint>(BigInt(0));
+
+const handleValueChange = (newValue: bigint) => {
+  value.value = newValue < 0 ? BigInt(0) : newValue;
+};
 
 const formatResponseIfNeeded = (response: string): string => {
   // Check if the string looks like a malformed JSON (starts with { and ends with })
@@ -88,6 +94,7 @@ const handleCallWriteMethod = async () => {
         args: calldataArguments.value.args,
         kwargs: calldataArguments.value.kwargs,
       }),
+      value: value.value,
     });
 
     notify({
@@ -140,6 +147,17 @@ const handleCallWriteMethod = async () => {
             }
           "
         />
+
+        <div v-if="methodType === 'write'" class="flex flex-col justify-start">
+          <component
+            :is="inputMap.getComponent('int')"
+            :model-value="value"
+            @update:model-value="handleValueChange"
+            name="value"
+            placeholder="0"
+            label="Value (wei)"
+          />
+        </div>
 
         <div>
           <Btn

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ContractMethod } from 'genlayer-js/types';
+import type { ContractMethod } from '@/types/contract';
 import { abi } from 'genlayer-js';
 import { ref } from 'vue';
 import { Collapse } from 'vue-collapsed';
@@ -148,7 +148,10 @@ const handleCallWriteMethod = async () => {
           "
         />
 
-        <div v-if="methodType === 'write'" class="flex flex-col justify-start">
+        <div
+          v-if="methodType === 'write' && props.method.payable"
+          class="flex flex-col justify-start"
+        >
           <component
             :is="inputMap.getComponent('int')"
             :model-value="value"

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -203,6 +203,7 @@ export function useContractQueries() {
     method,
     args,
     leaderOnly,
+    value,
   }: {
     method: string;
     args: {
@@ -210,6 +211,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     };
     leaderOnly: boolean;
+    value: bigint;
   }) {
     try {
       if (!accountsStore.selectedAccount) {
@@ -220,7 +222,7 @@ export function useContractQueries() {
         address: address.value as Address,
         functionName: method,
         args: args.args,
-        value: BigInt(0),
+        value: BigInt(value),
         leaderOnly,
       });
 

--- a/frontend/src/hooks/useSetupStores.ts
+++ b/frontend/src/hooks/useSetupStores.ts
@@ -68,7 +68,7 @@ export const useSetupStores = () => {
     consensusStore.fetchFinalityWindowTime();
 
     if (accountsStore.accounts.length < 1) {
-      accountsStore.generateNewAccount();
+      await accountsStore.generateNewAccount();
     }
 
     genlayer.initClient();

--- a/frontend/src/stores/accounts.ts
+++ b/frontend/src/stores/accounts.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import type { Address } from '@/types';
 import { createAccount, generatePrivateKey } from 'genlayer-js';
-import { useShortAddress } from '@/hooks';
+import { useShortAddress, useGenlayer } from '@/hooks';
 import { notify } from '@kyvg/vue3-notification';
 
 export interface AccountInfo {
@@ -17,6 +17,7 @@ export const useAccountsStore = defineStore('accountsStore', () => {
   // Store all accounts (both local and MetaMask)
   const accounts = ref<AccountInfo[]>([]);
   const selectedAccount = ref<AccountInfo | null>(null);
+  const genlayer = useGenlayer();
 
   // Migrate from old storage to new storage
   const storedKeys = localStorage.getItem('accountsStore.privateKeys');
@@ -33,20 +34,22 @@ export const useAccountsStore = defineStore('accountsStore', () => {
   const storedAccounts = JSON.parse(
     localStorage.getItem('accountsStore.accounts') || '[]',
   );
-  if (storedAccounts.length === 0) {
-    generateNewAccount();
-    _initAccountsLocalStorage();
-  } else {
-    accounts.value = storedAccounts;
-  }
+  (async () => {
+    if (storedAccounts.length === 0) {
+      await generateNewAccount();
+      _initAccountsLocalStorage();
+    } else {
+      accounts.value = storedAccounts;
+    }
 
-  // Initialize selected account from localStorage
-  const storedSelectedAccount = JSON.parse(
-    localStorage.getItem('accountsStore.currentAccount') || 'null',
-  );
-  setCurrentAccount(
-    storedSelectedAccount ? storedSelectedAccount : accounts.value[0],
-  );
+    // Initialize selected account
+    const storedSelectedAccount = JSON.parse(
+      localStorage.getItem('accountsStore.currentAccount') ?? 'null',
+    );
+    setCurrentAccount(
+      storedSelectedAccount ? storedSelectedAccount : accounts.value[0],
+    );
+  })();
 
   function _initAccountsLocalStorage() {
     localStorage.setItem(
@@ -125,7 +128,7 @@ export const useAccountsStore = defineStore('accountsStore', () => {
     });
   }
 
-  function generateNewAccount(): AccountInfo {
+  async function generateNewAccount(): Promise<AccountInfo> {
     const privateKey = generatePrivateKey();
     const newAccountAddress = createAccount(privateKey).address;
     const newAccount: AccountInfo = {
@@ -133,6 +136,11 @@ export const useAccountsStore = defineStore('accountsStore', () => {
       address: newAccountAddress,
       privateKey,
     };
+
+    await genlayer.client.value?.request({
+      method: 'sim_fundAccount',
+      params: [newAccount.address, 10000],
+    });
 
     accounts.value.push(newAccount);
     setCurrentAccount(newAccount);

--- a/frontend/src/types/contract.ts
+++ b/frontend/src/types/contract.ts
@@ -1,0 +1,5 @@
+import type { ContractMethod as BaseContractMethod } from 'genlayer-js/types';
+
+export interface ContractMethod extends BaseContractMethod {
+  payable?: boolean;
+}


### PR DESCRIPTION
Fixes #1028

# What

<!-- Describe the changes you made. -->

- Implemented value transfer between accounts in the consensus mechanism when the transaction is in the `ACCEPTED` state.
- Added error handling for transactions when the value sent is bigger than the sender's balance.
- Updated GenVM call to support a transaction value parameter.
- Added automatic account funding when creating new accounts in the frontend.
- Updated frontend components to handle account creation asynchronously.
- Frontend shows the value input field for write method when the decorator of the write method in the intelligent contract is `@gl.public.write.payable`.

# Todo
- Hardhat log error when sending value=10:
```
hardhat-1             |   Sender doesn't have enough funds to send tx. The max upfront cost is: 10 and the sender's balance is: 0.
jsonrpc-1             | [CONSENSUS_SERVICE]: Error forwarding transaction: {'code': -32000, 'message': "Sender doesn't have enough funds to send tx. The max upfront cost is: 10 and the sender's balance is: 0.", 'data': {'message': "Sender doesn't have enough funds to send tx. The max upfront cost is: 10 and the sender's balance is: 0.", 'data': None}}
```
- Showing the value field depends on the payable key in the contract schema. This schema will be updated in the next GenVM release. Once it is released:
   - Check if the code works.
   - Remove the frontend/src/types/contract.ts file and put that code in genlayer-js.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To adjust the balaces of the accounts in the database based on the value send with the transaction. 

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the funding of a newly create frontend account.
- Tested balance transfer when sending a value lower and higher than the sender's balance.
- Tested sending value when the decorator is not payable. This results in a GenVM error.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Decided to fund new frontend accounts with 10000. By calling `sim_fundAccount` the frontend account address is stored in the backend database and can be used when sending transactions with a value.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Depends on
This PR contains code from PR #1027.

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the changes in the consensus layer and GenVM for value handling.
- Review the error handling logic in the transactions processor and RPC endpoints.
- Check the frontend changes for asynchronous account creation and funding.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Transaction value is handled by GenVM and stored in the database.
- New frontend accounts are automatically funded upon creation.