### PR TITLE
fix: address typo in restore_stuck_transactions

### DIFF
--- a/backend/protocol_rpc/server.py
+++ b/backend/protocol_rpc/server.py
@@ -227,7 +227,7 @@ def restore_stuck_transactions():
                 )
             else:
                 contract_processor.update_contract_state(
-                    contract_address=tx1_accepted["to_address"],
+                    contract_address=tx2["to_address"],
                     accepted_state={},
                     finalized_state={},
                 )


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #DXP-213

# What

<!-- Describe the changes you made. -->

- Changed address from tx1_accepted to tx2 as tx1_accepted is None in the else case.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to fix a bug restore_stuck_transactions

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- tested the bug fix

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Check code change.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
Fix bug in restore_stuck_transactions regarding address selection.