### PR TITLE
fix: add default consensus history object for old transactions

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -254,6 +254,9 @@ class TransactionsProcessor:
         )
         transaction.status = new_status
 
+        if not transaction.consensus_history:
+            transaction.consensus_history = {}
+
         if "current_status_changes" in transaction.consensus_history:
             transaction.consensus_history["current_status_changes"].append(
                 new_status.value


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #DXP-231

# Added default consensus history to successufully restore old format stuck transactions