### PR TITLE
fix: avoid activating new transactions when the previous one is not accepted

### DIFF
--- a/backend/protocol_rpc/server.py
+++ b/backend/protocol_rpc/server.py
@@ -200,7 +200,7 @@ def restore_stuck_transactions():
 
         # Restore the contract state
         contract_processor = contract_processor_factory(request_session)
-        tx1_finalized = transactions_processor.previous_transaction_with_status(
+        tx1_finalized = transactions_processor.get_previous_transaction(
             tx2["hash"], TransactionStatus.FINALIZED
         )
         if tx1_finalized:
@@ -213,7 +213,7 @@ def restore_stuck_transactions():
                 finalized_state=previous_contact_state,
             )
         else:
-            tx1_accepted = transactions_processor.previous_transaction_with_status(
+            tx1_accepted = transactions_processor.get_previous_transaction(
                 tx2["hash"], TransactionStatus.ACCEPTED
             )
             if tx1_accepted:

--- a/tests/unit/consensus/test_helpers.py
+++ b/tests/unit/consensus/test_helpers.py
@@ -194,6 +194,11 @@ class TransactionsProcessorMock:
     def get_transaction_contract_snapshot(self, transaction_hash: str):
         return None
 
+    def get_previous_transaction(
+        self, transaction_hash: str, status: TransactionStatus | None = None
+    ) -> None:
+        return None
+
 
 class SnapshotMock:
     def __init__(self, nodes: list, transactions_processor: TransactionsProcessorMock):

--- a/webrequest/llms.py
+++ b/webrequest/llms.py
@@ -90,7 +90,6 @@ async def call_openai(
     stream = await get_openai_stream(client, prompt, node_config)
 
     result = await get_openai_output(stream, regex, return_streaming_channel)
-    print("bla: result", result)
     return result
 
 
@@ -116,8 +115,6 @@ async def get_openai_stream(client: AsyncOpenAI, prompt, node_config):
             and v is not None
         },
     }
-
-    print("bla: params", params)
 
     return await client.chat.completions.create(**params)
 


### PR DESCRIPTION
Fixes #DXP-242

# What

<!-- Describe the changes you made. -->

- Made status argument option in the method `previous_transaction_with_status` to reuse it and renamed it to `get_previous_transaction` in `transactions_processor`.
- Updated the logic in `ConsensusAlgorithm` to handle processing activated transactions more robustly by checking various conditions on the previous transaction.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To ensure that the consensus algorithm correctly handles transactions based on their status, preventing potential errors in state transitions.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the consensus algorithm to ensure it correctly processes transactions with the new logic.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Decided to replace the existing method with a more flexible one to accommodate future needs for transaction retrieval.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the changes.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Enhanced the consensus algorithm to handle transactions more robustly based on their status.