### PR TITLE
feat: stuck transactions due to llm call fails

### DIFF
--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -311,6 +311,19 @@ class Node:
             date=transaction_datetime,
             chain_id=SIMULATOR_CHAIN_ID,
         )
+        if res is None:
+            res = genvmbase.ExecutionResult(
+                eq_outputs={},
+                pending_transactions=[],
+                stdout="",
+                stderr="",
+                genvm_log=[],
+                result=genvmbase.ExecutionError(
+                    message="Execution timed out",
+                    kind=genvmbase.ResultCode.CONTRACT_ERROR,
+                ),
+            )
+
         await self._execution_finished(res, transaction_hash)
 
         result_exec_code = (

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -370,7 +370,7 @@ async def _run_genvm_host(
     tmpdir = Path(tempfile.mkdtemp())
     try:
         retries = 1
-        timeout = 1.0  # seconds
+        timeout = 30.0  # seconds
 
         for attempt in range(retries + 1):
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock_listener:

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -405,6 +405,9 @@ async def _run_genvm_host(
                     print(
                         f"GenVM execution timed out after {timeout} seconds (attempt {attempt + 1}/{retries + 1})"
                     )
+                except Exception as e:
+                    if "GenVM internal error" in str(e):
+                        print("GenVM internal error occurred:", e)
                 finally:
                     if host.sock is not None:
                         host.sock.close()


### PR DESCRIPTION
Fixes #DXP-243

# What

<!-- Describe the changes you made. -->

- Added exception handling for "GenVM internal error" in the `_run_genvm_host` function within `backend/node/genvm/base.py` so transactions are not stuck.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To handle GenVM internal errors gracefully, allowing transactions to go to an undetermined or accepted state rather than causing a crash.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested in the studio with a wrong API key.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Decided to catch all exceptions containing "GenVM internal error".

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the error handling logic to ensure it covers all potential GenVM internal errors.
- Verify that the logging provides sufficient information for debugging purposes.

# Depends on
This PR contains code from PR #1129. It contains the retry mechanism.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Improved error handling for GenVM internal errors, ensuring that transactions are not stuck.