### PR TITLE
fix: consensus history updated before logevent

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -622,6 +622,7 @@ class ConsensusAlgorithm:
         transaction_hash: str,
         new_status: TransactionStatus,
         msg_handler: MessageHandler,
+        update_current_status_changes: bool = True,
     ):
         """
         Dispatch a transaction status update.
@@ -633,7 +634,11 @@ class ConsensusAlgorithm:
             msg_handler (MessageHandler): Handler for messaging.
         """
         # Update the transaction status in the transactions processor
-        transactions_processor.update_transaction_status(transaction_hash, new_status)
+        transactions_processor.update_transaction_status(
+            transaction_hash,
+            new_status,
+            update_current_status_changes,
+        )
 
         # Send a message indicating the transaction status update
         msg_handler.send_message(
@@ -2091,14 +2096,6 @@ class AcceptedState(TransactionState):
             context.transaction.hash, context.consensus_data.to_dict()
         )
 
-        # Update the transaction status to ACCEPTED
-        ConsensusAlgorithm.dispatch_transaction_status_update(
-            context.transactions_processor,
-            context.transaction.hash,
-            TransactionStatus.ACCEPTED,
-            context.msg_handler,
-        )
-
         context.transactions_processor.update_consensus_history(
             context.transaction.hash,
             consensus_round,
@@ -2108,6 +2105,16 @@ class AcceptedState(TransactionState):
                 else context.consensus_data.leader_receipt
             ),
             context.validation_results,
+            TransactionStatus.ACCEPTED,
+        )
+
+        # Update the transaction status to ACCEPTED
+        ConsensusAlgorithm.dispatch_transaction_status_update(
+            context.transactions_processor,
+            context.transaction.hash,
+            TransactionStatus.ACCEPTED,
+            context.msg_handler,
+            False,
         )
 
         # Send a message indicating consensus was reached
@@ -2274,19 +2281,21 @@ class UndeterminedState(TransactionState):
                 context.transaction.hash
             )
 
+        context.transactions_processor.update_consensus_history(
+            context.transaction.hash,
+            consensus_round,
+            context.consensus_data.leader_receipt,
+            context.consensus_data.validators,
+            TransactionStatus.UNDETERMINED,
+        )
+
         # Update the transaction status to undetermined
         ConsensusAlgorithm.dispatch_transaction_status_update(
             context.transactions_processor,
             context.transaction.hash,
             TransactionStatus.UNDETERMINED,
             context.msg_handler,
-        )
-
-        context.transactions_processor.update_consensus_history(
-            context.transaction.hash,
-            consensus_round,
-            context.consensus_data.leader_receipt,
-            context.consensus_data.validators,
+            False,
         )
 
         return None

--- a/tests/unit/consensus/test_helpers.py
+++ b/tests/unit/consensus/test_helpers.py
@@ -49,22 +49,26 @@ class TransactionsProcessorMock:
         raise ValueError(f"Transaction with hash {transaction_hash} not found")
 
     def update_transaction_status(
-        self, transaction_hash: str, new_status: TransactionStatus
+        self,
+        transaction_hash: str,
+        new_status: TransactionStatus,
+        update_current_status_changes: bool = True,
     ):
         with self.status_update_lock:
             transaction = self.get_transaction_by_hash(transaction_hash)
             transaction["status"] = new_status.value
             self.updated_transaction_status_history[transaction_hash].append(new_status)
 
-            if "current_status_changes" in transaction["consensus_history"]:
-                transaction["consensus_history"]["current_status_changes"].append(
-                    new_status.value
-                )
-            else:
-                transaction["consensus_history"]["current_status_changes"] = [
-                    TransactionStatus.PENDING.value,
-                    new_status.value,
-                ]
+            if update_current_status_changes:
+                if "current_status_changes" in transaction["consensus_history"]:
+                    transaction["consensus_history"]["current_status_changes"].append(
+                        new_status.value
+                    )
+                else:
+                    transaction["consensus_history"]["current_status_changes"] = [
+                        TransactionStatus.PENDING.value,
+                        new_status.value,
+                    ]
 
             self.status_changed_event.set()
 
@@ -155,18 +159,23 @@ class TransactionsProcessorMock:
         consensus_round: str,
         leader_result: dict | None,
         validator_results: list,
+        extra_status_change: TransactionStatus | None = None,
     ):
         transaction = self.get_transaction_by_hash(transaction_hash)
+
+        status_changes_to_use = (
+            transaction["consensus_history"]["current_status_changes"]
+            if "current_status_changes" in transaction["consensus_history"]
+            else []
+        )
+        if extra_status_change:
+            status_changes_to_use.append(extra_status_change.value)
 
         current_consensus_results = {
             "consensus_round": consensus_round,
             "leader_result": leader_result.to_dict() if leader_result else None,
             "validator_results": [receipt.to_dict() for receipt in validator_results],
-            "status_changes": (
-                transaction["consensus_history"]["current_status_changes"]
-                if "current_status_changes" in transaction["consensus_history"]
-                else []
-            ),
+            "status_changes": status_changes_to_use,
         }
         if "consensus_results" in transaction["consensus_history"]:
             transaction["consensus_history"]["consensus_results"].append(


### PR DESCRIPTION
Fixes #DXP-76

# What

- Added a new parameter `update_current_status_changes` to the `dispatch_transaction_status_update` method in `ConsensusAlgorithm` to control whether the status should be updated in the consensus history.
- Updated the `update_transaction_status` method in `TransactionsProcessor` to handle the new parameter and conditionally update the `current_status_changes`.
- Modified the `update_consensus_history` method to include an optional `extra_status_change` parameter for additional status changes.
- Simplified the Dockerfile by removing unnecessary steps for ARM64 platform.

# Why

- To provide more control over the transaction status update process, allowing for conditional updates to the current status changes.
- To streamline the Dockerfile and remove redundant steps, improving build efficiency.

# Testing done

- Tested in the studio sending a failed leader appeal.

# Decisions made

- Decided to add the `update_current_status_changes` parameter to provide flexibility in transaction status updates.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the changes in the `ConsensusAlgorithm` and `TransactionsProcessor` classes to understand the new parameter's impact.

# User facing release notes

- Introduced a new parameter to control transaction status updates.