### PR TITLE
chore: fixing genlayer-js version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "defu": "^6.1.4",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^0.9.0",
+    "genlayer-js": "0.9.0",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
pinning genlayer-js version