### PR TITLE
fix: remove private_key from validators for endpoints methods

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -304,13 +304,15 @@ def delete_all_validators(
 
 
 def get_all_validators(validators_registry: ValidatorsRegistry) -> list:
-    return validators_registry.get_all_validators()
+    return validators_registry.get_all_validators(include_private_key=False)
 
 
 def get_validator(
     validators_registry: ValidatorsRegistry, validator_address: str
 ) -> dict:
-    return validators_registry.get_validator(validator_address)
+    return validators_registry.get_validator(
+        validator_address=validator_address, include_private_key=False
+    )
 
 
 def count_validators(validators_registry: ValidatorsRegistry) -> int:

--- a/tests/db-sqlalchemy/validators_registry_test.py
+++ b/tests/db-sqlalchemy/validators_registry_test.py
@@ -71,7 +71,9 @@ def test_validators_registry(validators_registry: ValidatorsRegistry):
 
     assert validators_registry.count_validators() == 1
 
-    assert validators_registry.get_validator(validator_address) == actual_validator
+    assert (
+        validators_registry.get_validator(validator_address, False) == actual_validator
+    )
 
     assert actual_validator["stake"] == new_stake
     assert actual_validator["provider"] == new_provider


### PR DESCRIPTION
Fixes #DXP-289
# What

- Updated the `to_dict` function in `validators_registry.py` to include an optional `include_private_key` parameter, allowing control over whether the `private_key` is included in the dictionary representation of a `Validator`.
- Modified the `get_all_validators` and `get_validator` methods in `ValidatorsRegistry` to accept the `include_private_key` parameter, providing flexibility in returning validator data with or without the private key.
- Updated the `create_validator` and `update_validator` methods to exclude the private key from the returned dictionary by default.
- Adjusted the `get_all_validators` and `get_validator` functions in `endpoints.py` to call the updated methods with `include_private_key=False`. So frontend and rpc calls won't have the private key.

# Why

- To enhance security by allowing the exclusion of sensitive `private_key` information from the dictionary representation of validators when not needed.
- To ensure that the `private_key` is not exposed unnecessarily in API responses, aligning with best practices for handling sensitive data.

# Testing done

- Ran the studio. Check validator creation and transaction execution.

# Decisions made

- Decided to default the `include_private_key` parameter to `False` in API endpoint functions.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the changes in `validators_registry.py` and `endpoints.py` to ensure the handling of the `include_private_key` parameter is consistent and secure.

# User facing release notes

- Enhanced security by allowing API responses to exclude sensitive `private_key` information from validator data.