### PR TITLE
fix: install google-chrome-stable from Google's repo

### DIFF
--- a/docker/Dockerfile.webdriver
+++ b/docker/Dockerfile.webdriver
@@ -35,27 +35,8 @@ RUN \
     chromium --version ; \
     true
 
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    gnupg \
-    curl \
-#     unzip \
-#     jq \
-#     openjdk-17-jre-headless \
-#     fonts-open-sans \
-#     mesa-vulkan-drivers \
-    && rm -rf /var/lib/apt/lists/*
-
-# Add Google Chrome repository
-RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-
-# Install Google Chrome
-RUN apt-get update && apt-get install -y google-chrome-stable && rm -rf /var/lib/apt/lists/*
-
-# Install ChromeDriver matching Chrome version
-ADD --checksum=sha256:d9b388d8dc609f89332662a824899a0ed702a26c8dfd824e9a24a4e5fa44a197 \
-    https://storage.googleapis.com/chrome-for-testing-public/136.0.7103.49/linux64/chromedriver-linux64.zip \
+ADD --checksum=sha256:64e1f8bf5bbb94983dff82874b79f45039e5463323e8912d38b83a1277f9e272 \
+https://storage.googleapis.com/chrome-for-testing-public/135.0.7049.95/linux64/chromedriver-linux64.zip \
     /download/chrome-driver.zip
 
 ADD --checksum=sha256:aa3bd6e9820a359a54da0cf06836ad42a7555ee13b5235ff60228f637db9bb57 \

--- a/docker/Dockerfile.webdriver
+++ b/docker/Dockerfile.webdriver
@@ -35,8 +35,27 @@ RUN \
     chromium --version ; \
     true
 
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    gnupg \
+    curl \
+#     unzip \
+#     jq \
+#     openjdk-17-jre-headless \
+#     fonts-open-sans \
+#     mesa-vulkan-drivers \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Google Chrome repository
+RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+
+# Install Google Chrome
+RUN apt-get update && apt-get install -y google-chrome-stable && rm -rf /var/lib/apt/lists/*
+
+# Install ChromeDriver matching Chrome version
 ADD --checksum=sha256:d9b388d8dc609f89332662a824899a0ed702a26c8dfd824e9a24a4e5fa44a197 \
-https://storage.googleapis.com/chrome-for-testing-public/136.0.7103.49/linux64/chromedriver-linux64.zip \
+    https://storage.googleapis.com/chrome-for-testing-public/136.0.7103.49/linux64/chromedriver-linux64.zip \
     /download/chrome-driver.zip
 
 ADD --checksum=sha256:aa3bd6e9820a359a54da0cf06836ad42a7555ee13b5235ff60228f637db9bb57 \

--- a/tests/unit/consensus/test_base.py
+++ b/tests/unit/consensus/test_base.py
@@ -348,6 +348,7 @@ async def test_exec_accepted_appeal_successful(consensus_algorithm):
             }
         }
     )
+    check_contract_state(contract_db, transaction.to_address, {}, {})
 
     def get_vote():
         """
@@ -371,7 +372,6 @@ async def test_exec_accepted_appeal_successful(consensus_algorithm):
     )
 
     try:
-        check_contract_state(contract_db, transaction.to_address, {}, {})
         assert_transaction_status_match(
             transactions_processor, transaction, [TransactionStatus.ACCEPTED.value]
         )
@@ -1233,6 +1233,7 @@ async def test_exec_undetermined_appeal(consensus_algorithm):
             }
         }
     )
+    check_contract_state(contract_db, transaction.to_address, {}, {})
 
     def get_vote():
         """
@@ -1268,7 +1269,6 @@ async def test_exec_undetermined_appeal(consensus_algorithm):
     )
 
     try:
-        check_contract_state(contract_db, transaction.to_address, {}, {})
         assert_transaction_status_match(
             transactions_processor, transaction, [TransactionStatus.UNDETERMINED.value]
         )
@@ -1492,6 +1492,7 @@ async def test_exec_validator_appeal_success_with_rollback_second_tx(
             }
         }
     )
+    check_contract_state(contract_db, transaction_1.to_address, {}, {})
 
     consensus_algorithm.finality_window_time = 60
 
@@ -1523,7 +1524,6 @@ async def test_exec_validator_appeal_success_with_rollback_second_tx(
 
     try:
         contract_address = transaction_1.to_address
-        check_contract_state(contract_db, contract_address, {}, {})
 
         assert_transaction_status_match(
             transactions_processor, transaction_1, [TransactionStatus.ACCEPTED.value]
@@ -1629,6 +1629,7 @@ async def test_exec_leader_appeal_succes_with_rollback_second_tx(consensus_algor
             }
         }
     )
+    check_contract_state(contract_db, transaction_1.to_address, {}, {})
     consensus_algorithm.finality_window_time = 60
 
     def get_vote():
@@ -1656,7 +1657,6 @@ async def test_exec_leader_appeal_succes_with_rollback_second_tx(consensus_algor
 
     try:
         contract_address = transaction_1.to_address
-        check_contract_state(contract_db, contract_address, {}, {})
 
         assert_transaction_status_match(
             transactions_processor,


### PR DESCRIPTION
Fixes #DXP-299

# What

- Updated the Dockerfile `docker/Dockerfile.webdriver` to downgrade the chrome driver to 135.

# Why

- To ensure the Docker image works with the version of Google Chrome.

# Testing done

- Ran studio.

# Decisions made

Another approach is to get the Google Chrome repository and install Google Chrome.
```
RUN apt-get update && apt-get install -y \
    gnupg \
    curl \
    && rm -rf /var/lib/apt/lists/*

RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome.gpg \
    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list

RUN apt-get update && apt-get install -y google-chrome-stable && rm -rf /var/lib/apt/lists/*
```

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Ensure that the Docker image builds successfully with the new changes.

# User facing release notes

- Updated Docker image to downgrade the chrome driver to 135.