### PR TITLE
fix: make snapshots endpoints to be forbidden in hosted studio

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -754,6 +754,7 @@ def get_contract(consensus_service: ConsensusService, contract_name: str) -> dic
     }
 
 
+@check_forbidden_method_in_hosted_studio
 def create_snapshot(
     snapshot_manager: SnapshotManager,
 ) -> int:
@@ -766,6 +767,7 @@ def create_snapshot(
     return snapshot.snapshot_id
 
 
+@check_forbidden_method_in_hosted_studio
 def restore_snapshot(
     snapshot_manager: SnapshotManager,
     snapshot_id: int,
@@ -782,6 +784,7 @@ def restore_snapshot(
     return reverted
 
 
+@check_forbidden_method_in_hosted_studio
 def delete_all_snapshots(
     snapshot_manager: SnapshotManager,
 ) -> dict:


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes DXP-310

# What

<!-- Describe the changes you made. -->

- Added check forbidden to the snapshots endpoints
  - sim_createSnapshot
  - sim_restoreSnapshot
  - sim_deleteAllSnapshots

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- It was intended to be a feature for local development
- `sim_restoreSnapshot` can cause integrity errors in contract state data

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested that currently, any user can call snapshot endpoints on the hosted studio


# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Used `check_forbidden_method_in_hosted_studio`  wrapper to block endpoints in hosted studio

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

